### PR TITLE
Webhooks Feature

### DIFF
--- a/Xrm.Sdk.PluginRegistration/Controls/CrmTreeControl.cs
+++ b/Xrm.Sdk.PluginRegistration/Controls/CrmTreeControl.cs
@@ -75,7 +75,8 @@ namespace Xrm.Sdk.PluginRegistration.Controls
         Image = 64,
         Message = 128,
         MessageEntity = 256,
-        ServiceEndpoint = 512
+        ServiceEndpoint = 512,
+        WebHook = 1024
     }
 
     public interface ICrmEditableTreeNode : ICrmTreeNode

--- a/Xrm.Sdk.PluginRegistration/Entities/ServiceEndpoint.cs
+++ b/Xrm.Sdk.PluginRegistration/Entities/ServiceEndpoint.cs
@@ -75,6 +75,24 @@
         }
 
         /// <summary>
+        /// Connection mode to contact the service endpoint.
+        /// </summary>
+        [AttributeLogicalName("authtype")]
+        public OptionSetValue AuthType
+        {
+            get
+            {
+                return GetAttributeValue<OptionSetValue>("authtype");
+            }
+            set
+            {
+                OnPropertyChanging("AuthType");
+                SetAttributeValue("authtype", value);
+                OnPropertyChanged("AuthType");
+            }
+        }
+
+        /// <summary>
         /// Type of the endpoint contract.
         /// </summary>
         [AttributeLogicalName("contract")]
@@ -143,6 +161,42 @@
                 OnPropertyChanging("Description");
                 SetAttributeValue("description", value);
                 OnPropertyChanged("Description");
+            }
+        }
+
+        /// <summary>
+        /// Description of the service endpoint.
+        /// </summary>
+        [AttributeLogicalName("authvalue")]
+        public string AuthValue
+        {
+            get
+            {
+                return GetAttributeValue<string>("authvalue");
+            }
+            set
+            {
+                OnPropertyChanging("AuthValue");
+                SetAttributeValue("authvalue", value);
+                OnPropertyChanged("AuthValue");
+            }
+        }
+
+        /// <summary>
+        /// Url of webhook.
+        /// </summary>
+        [AttributeLogicalName("url")]
+        public string Url
+        {
+            get
+            {
+                return GetAttributeValue<string>("url");
+            }
+            set
+            {
+                OnPropertyChanging("Url");
+                SetAttributeValue("url", value);
+                OnPropertyChanged("Url");
             }
         }
 

--- a/Xrm.Sdk.PluginRegistration/Forms/StepRegistrationForm.Designer.cs
+++ b/Xrm.Sdk.PluginRegistration/Forms/StepRegistrationForm.Designer.cs
@@ -76,6 +76,7 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             this.chkDeleteAsyncOperationIfSuccessful = new System.Windows.Forms.CheckBox();
             this.grpDescription = new System.Windows.Forms.GroupBox();
             this.txtDescription = new System.Windows.Forms.TextBox();
+            this.cmbWebhook = new System.Windows.Forms.ComboBox();
             this.grpGeneral.SuspendLayout();
             this.grpSecureConfiguration.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.picInvalidSecureConfigurationId)).BeginInit();
@@ -91,7 +92,6 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             // grpGeneral
             // 
             this.grpGeneral.Controls.Add(this.cmbServiceEndpoint);
-            this.grpGeneral.Controls.Add(this.cmbPlugins);
             this.grpGeneral.Controls.Add(this.lblFilteringAttributes);
             this.grpGeneral.Controls.Add(this.lblEventHandler);
             this.grpGeneral.Controls.Add(this.txtRank);
@@ -106,9 +106,13 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             this.grpGeneral.Controls.Add(this.lblPrimaryEntity);
             this.grpGeneral.Controls.Add(this.txtMessageName);
             this.grpGeneral.Controls.Add(this.lblMessageName);
-            this.grpGeneral.Location = new System.Drawing.Point(12, 12);
+            this.grpGeneral.Controls.Add(this.cmbWebhook);
+            this.grpGeneral.Controls.Add(this.cmbPlugins);
+            this.grpGeneral.Location = new System.Drawing.Point(18, 18);
+            this.grpGeneral.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.grpGeneral.Name = "grpGeneral";
-            this.grpGeneral.Size = new System.Drawing.Size(451, 229);
+            this.grpGeneral.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.grpGeneral.Size = new System.Drawing.Size(676, 352);
             this.grpGeneral.TabIndex = 0;
             this.grpGeneral.TabStop = false;
             this.grpGeneral.Text = "General Configuration Information";
@@ -121,9 +125,10 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             this.cmbServiceEndpoint.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.cmbServiceEndpoint.DisplayMember = "NodeText";
             this.cmbServiceEndpoint.FormattingEnabled = true;
-            this.cmbServiceEndpoint.Location = new System.Drawing.Point(127, 117);
+            this.cmbServiceEndpoint.Location = new System.Drawing.Point(190, 180);
+            this.cmbServiceEndpoint.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.cmbServiceEndpoint.Name = "cmbServiceEndpoint";
-            this.cmbServiceEndpoint.Size = new System.Drawing.Size(109, 21);
+            this.cmbServiceEndpoint.Size = new System.Drawing.Size(162, 28);
             this.cmbServiceEndpoint.TabIndex = 12;
             // 
             // cmbPlugins
@@ -133,9 +138,10 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             this.cmbPlugins.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
             this.cmbPlugins.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.cmbPlugins.FormattingEnabled = true;
-            this.cmbPlugins.Location = new System.Drawing.Point(127, 117);
+            this.cmbPlugins.Location = new System.Drawing.Point(190, 180);
+            this.cmbPlugins.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.cmbPlugins.Name = "cmbPlugins";
-            this.cmbPlugins.Size = new System.Drawing.Size(316, 21);
+            this.cmbPlugins.Size = new System.Drawing.Size(472, 28);
             this.cmbPlugins.Sorted = true;
             this.cmbPlugins.TabIndex = 12;
             this.cmbPlugins.SelectedIndexChanged += new System.EventHandler(this.cmbPlugins_SelectedIndexChanged);
@@ -143,18 +149,20 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             // lblFilteringAttributes
             // 
             this.lblFilteringAttributes.AutoSize = true;
-            this.lblFilteringAttributes.Location = new System.Drawing.Point(9, 94);
+            this.lblFilteringAttributes.Location = new System.Drawing.Point(14, 145);
+            this.lblFilteringAttributes.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblFilteringAttributes.Name = "lblFilteringAttributes";
-            this.lblFilteringAttributes.Size = new System.Drawing.Size(93, 13);
+            this.lblFilteringAttributes.Size = new System.Drawing.Size(142, 20);
             this.lblFilteringAttributes.TabIndex = 8;
             this.lblFilteringAttributes.Text = "Filtering Attributes:";
             // 
             // lblEventHandler
             // 
             this.lblEventHandler.AutoSize = true;
-            this.lblEventHandler.Location = new System.Drawing.Point(9, 120);
+            this.lblEventHandler.Location = new System.Drawing.Point(14, 185);
+            this.lblEventHandler.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblEventHandler.Name = "lblEventHandler";
-            this.lblEventHandler.Size = new System.Drawing.Size(78, 13);
+            this.lblEventHandler.Size = new System.Drawing.Size(114, 20);
             this.lblEventHandler.TabIndex = 11;
             this.lblEventHandler.Text = "Event Handler:";
             // 
@@ -162,9 +170,10 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             // 
             this.txtRank.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtRank.Location = new System.Drawing.Point(127, 198);
+            this.txtRank.Location = new System.Drawing.Point(190, 305);
+            this.txtRank.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.txtRank.Name = "txtRank";
-            this.txtRank.Size = new System.Drawing.Size(316, 20);
+            this.txtRank.Size = new System.Drawing.Size(472, 26);
             this.txtRank.TabIndex = 18;
             this.txtRank.Text = "1";
             this.txtRank.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.txtRank_KeyPress);
@@ -172,9 +181,10 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             // lblRank
             // 
             this.lblRank.AutoSize = true;
-            this.lblRank.Location = new System.Drawing.Point(9, 200);
+            this.lblRank.Location = new System.Drawing.Point(14, 308);
+            this.lblRank.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblRank.Name = "lblRank";
-            this.lblRank.Size = new System.Drawing.Size(86, 13);
+            this.lblRank.Size = new System.Drawing.Size(127, 20);
             this.lblRank.TabIndex = 17;
             this.lblRank.Text = "Execution Order:";
             // 
@@ -184,17 +194,19 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             | System.Windows.Forms.AnchorStyles.Right)));
             this.cmbUsers.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
             this.cmbUsers.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
-            this.cmbUsers.Location = new System.Drawing.Point(127, 170);
+            this.cmbUsers.Location = new System.Drawing.Point(190, 262);
+            this.cmbUsers.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.cmbUsers.Name = "cmbUsers";
-            this.cmbUsers.Size = new System.Drawing.Size(316, 21);
+            this.cmbUsers.Size = new System.Drawing.Size(472, 28);
             this.cmbUsers.TabIndex = 16;
             // 
             // lblImpersonation
             // 
             this.lblImpersonation.AutoSize = true;
-            this.lblImpersonation.Location = new System.Drawing.Point(9, 173);
+            this.lblImpersonation.Location = new System.Drawing.Point(14, 266);
+            this.lblImpersonation.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblImpersonation.Name = "lblImpersonation";
-            this.lblImpersonation.Size = new System.Drawing.Size(112, 13);
+            this.lblImpersonation.Size = new System.Drawing.Size(167, 20);
             this.lblImpersonation.TabIndex = 15;
             this.lblImpersonation.Text = "Run in User\'s Context:";
             // 
@@ -202,9 +214,10 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             // 
             this.txtName.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtName.Location = new System.Drawing.Point(127, 144);
+            this.txtName.Location = new System.Drawing.Point(190, 222);
+            this.txtName.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.txtName.Name = "txtName";
-            this.txtName.Size = new System.Drawing.Size(316, 20);
+            this.txtName.Size = new System.Drawing.Size(472, 26);
             this.txtName.TabIndex = 14;
             this.txtName.TextChanged += new System.EventHandler(this.txtName_TextChanged);
             this.txtName.Leave += new System.EventHandler(this.txtName_Leave);
@@ -212,9 +225,10 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             // lblDescription
             // 
             this.lblDescription.AutoSize = true;
-            this.lblDescription.Location = new System.Drawing.Point(9, 147);
+            this.lblDescription.Location = new System.Drawing.Point(14, 226);
+            this.lblDescription.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblDescription.Name = "lblDescription";
-            this.lblDescription.Size = new System.Drawing.Size(38, 13);
+            this.lblDescription.Size = new System.Drawing.Size(55, 20);
             this.lblDescription.TabIndex = 13;
             this.lblDescription.Text = "Name:";
             // 
@@ -224,9 +238,10 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             | System.Windows.Forms.AnchorStyles.Right)));
             this.txtSecondaryEntity.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
             this.txtSecondaryEntity.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.CustomSource;
-            this.txtSecondaryEntity.Location = new System.Drawing.Point(127, 65);
+            this.txtSecondaryEntity.Location = new System.Drawing.Point(190, 100);
+            this.txtSecondaryEntity.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.txtSecondaryEntity.Name = "txtSecondaryEntity";
-            this.txtSecondaryEntity.Size = new System.Drawing.Size(316, 20);
+            this.txtSecondaryEntity.Size = new System.Drawing.Size(472, 26);
             this.txtSecondaryEntity.TabIndex = 7;
             this.txtSecondaryEntity.TextChanged += new System.EventHandler(this.MessageData_TextChanged);
             this.txtSecondaryEntity.Leave += new System.EventHandler(this.MessageEntityData_Leave);
@@ -234,9 +249,10 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             // lblSecondaryEntity
             // 
             this.lblSecondaryEntity.AutoSize = true;
-            this.lblSecondaryEntity.Location = new System.Drawing.Point(9, 68);
+            this.lblSecondaryEntity.Location = new System.Drawing.Point(14, 105);
+            this.lblSecondaryEntity.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblSecondaryEntity.Name = "lblSecondaryEntity";
-            this.lblSecondaryEntity.Size = new System.Drawing.Size(90, 13);
+            this.lblSecondaryEntity.Size = new System.Drawing.Size(133, 20);
             this.lblSecondaryEntity.TabIndex = 6;
             this.lblSecondaryEntity.Text = "Secondary Entity:";
             // 
@@ -246,9 +262,10 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             | System.Windows.Forms.AnchorStyles.Right)));
             this.txtPrimaryEntity.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
             this.txtPrimaryEntity.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.CustomSource;
-            this.txtPrimaryEntity.Location = new System.Drawing.Point(127, 39);
+            this.txtPrimaryEntity.Location = new System.Drawing.Point(190, 60);
+            this.txtPrimaryEntity.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.txtPrimaryEntity.Name = "txtPrimaryEntity";
-            this.txtPrimaryEntity.Size = new System.Drawing.Size(316, 20);
+            this.txtPrimaryEntity.Size = new System.Drawing.Size(472, 26);
             this.txtPrimaryEntity.TabIndex = 5;
             this.txtPrimaryEntity.TextChanged += new System.EventHandler(this.MessageData_TextChanged);
             this.txtPrimaryEntity.Leave += new System.EventHandler(this.MessageEntityData_Leave);
@@ -256,9 +273,10 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             // lblPrimaryEntity
             // 
             this.lblPrimaryEntity.AutoSize = true;
-            this.lblPrimaryEntity.Location = new System.Drawing.Point(9, 42);
+            this.lblPrimaryEntity.Location = new System.Drawing.Point(14, 65);
+            this.lblPrimaryEntity.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblPrimaryEntity.Name = "lblPrimaryEntity";
-            this.lblPrimaryEntity.Size = new System.Drawing.Size(73, 13);
+            this.lblPrimaryEntity.Size = new System.Drawing.Size(109, 20);
             this.lblPrimaryEntity.TabIndex = 4;
             this.lblPrimaryEntity.Text = "&Primary Entity:";
             // 
@@ -268,9 +286,10 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             | System.Windows.Forms.AnchorStyles.Right)));
             this.txtMessageName.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
             this.txtMessageName.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.CustomSource;
-            this.txtMessageName.Location = new System.Drawing.Point(127, 13);
+            this.txtMessageName.Location = new System.Drawing.Point(190, 20);
+            this.txtMessageName.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.txtMessageName.Name = "txtMessageName";
-            this.txtMessageName.Size = new System.Drawing.Size(316, 20);
+            this.txtMessageName.Size = new System.Drawing.Size(472, 26);
             this.txtMessageName.TabIndex = 3;
             this.txtMessageName.TextChanged += new System.EventHandler(this.MessageData_TextChanged);
             this.txtMessageName.Leave += new System.EventHandler(this.txtMessageName_Leave);
@@ -279,9 +298,10 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             // lblMessageName
             // 
             this.lblMessageName.AutoSize = true;
-            this.lblMessageName.Location = new System.Drawing.Point(9, 16);
+            this.lblMessageName.Location = new System.Drawing.Point(14, 25);
+            this.lblMessageName.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblMessageName.Name = "lblMessageName";
-            this.lblMessageName.Size = new System.Drawing.Size(53, 13);
+            this.lblMessageName.Size = new System.Drawing.Size(78, 20);
             this.lblMessageName.TabIndex = 1;
             this.lblMessageName.Text = "Message:";
             // 
@@ -296,9 +316,11 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             this.grpSecureConfiguration.Controls.Add(this.lblAccessDenied);
             this.grpSecureConfiguration.Controls.Add(this.picAccessDenied);
             this.grpSecureConfiguration.Controls.Add(this.txtSecureConfig);
-            this.grpSecureConfiguration.Location = new System.Drawing.Point(469, 238);
+            this.grpSecureConfiguration.Location = new System.Drawing.Point(704, 366);
+            this.grpSecureConfiguration.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.grpSecureConfiguration.Name = "grpSecureConfiguration";
-            this.grpSecureConfiguration.Size = new System.Drawing.Size(433, 170);
+            this.grpSecureConfiguration.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.grpSecureConfiguration.Size = new System.Drawing.Size(650, 262);
             this.grpSecureConfiguration.TabIndex = 9;
             this.grpSecureConfiguration.TabStop = false;
             this.grpSecureConfiguration.Text = "Secure Configuration";
@@ -310,9 +332,10 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             // 
             this.lnkInvalidSecureConfigurationId.Anchor = System.Windows.Forms.AnchorStyles.None;
             this.lnkInvalidSecureConfigurationId.AutoSize = true;
-            this.lnkInvalidSecureConfigurationId.Location = new System.Drawing.Point(73, 151);
+            this.lnkInvalidSecureConfigurationId.Location = new System.Drawing.Point(110, 232);
+            this.lnkInvalidSecureConfigurationId.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lnkInvalidSecureConfigurationId.Name = "lnkInvalidSecureConfigurationId";
-            this.lnkInvalidSecureConfigurationId.Size = new System.Drawing.Size(137, 13);
+            this.lnkInvalidSecureConfigurationId.Size = new System.Drawing.Size(206, 20);
             this.lnkInvalidSecureConfigurationId.TabIndex = 10;
             this.lnkInvalidSecureConfigurationId.TabStop = true;
             this.lnkInvalidSecureConfigurationId.Text = "Reset Secure Configuration";
@@ -322,9 +345,10 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             // lblInvalidSecureConfigurationId
             // 
             this.lblInvalidSecureConfigurationId.Anchor = System.Windows.Forms.AnchorStyles.None;
-            this.lblInvalidSecureConfigurationId.Location = new System.Drawing.Point(73, 101);
+            this.lblInvalidSecureConfigurationId.Location = new System.Drawing.Point(110, 155);
+            this.lblInvalidSecureConfigurationId.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblInvalidSecureConfigurationId.Name = "lblInvalidSecureConfigurationId";
-            this.lblInvalidSecureConfigurationId.Size = new System.Drawing.Size(307, 48);
+            this.lblInvalidSecureConfigurationId.Size = new System.Drawing.Size(460, 74);
             this.lblInvalidSecureConfigurationId.TabIndex = 9;
             this.lblInvalidSecureConfigurationId.Text = "The ID specified in the Secure Configuration appears to be invalid, which usually" +
     " indicates that the step or secure configuration has been edited with the SDK.";
@@ -334,9 +358,10 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             // picInvalidSecureConfigurationId
             // 
             this.picInvalidSecureConfigurationId.Anchor = System.Windows.Forms.AnchorStyles.None;
-            this.picInvalidSecureConfigurationId.Location = new System.Drawing.Point(25, 101);
+            this.picInvalidSecureConfigurationId.Location = new System.Drawing.Point(38, 155);
+            this.picInvalidSecureConfigurationId.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.picInvalidSecureConfigurationId.Name = "picInvalidSecureConfigurationId";
-            this.picInvalidSecureConfigurationId.Size = new System.Drawing.Size(48, 48);
+            this.picInvalidSecureConfigurationId.Size = new System.Drawing.Size(72, 74);
             this.picInvalidSecureConfigurationId.TabIndex = 8;
             this.picInvalidSecureConfigurationId.TabStop = false;
             this.picInvalidSecureConfigurationId.Visible = false;
@@ -344,9 +369,10 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             // lblAccessDenied
             // 
             this.lblAccessDenied.Anchor = System.Windows.Forms.AnchorStyles.None;
-            this.lblAccessDenied.Location = new System.Drawing.Point(73, 24);
+            this.lblAccessDenied.Location = new System.Drawing.Point(110, 37);
+            this.lblAccessDenied.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblAccessDenied.Name = "lblAccessDenied";
-            this.lblAccessDenied.Size = new System.Drawing.Size(307, 48);
+            this.lblAccessDenied.Size = new System.Drawing.Size(460, 74);
             this.lblAccessDenied.TabIndex = 6;
             this.lblAccessDenied.Text = "Unable to retrieve Secure Configuration. This may be because you do not have acce" +
     "ss to Secure Configuration values. No changes will be saved for this field.";
@@ -356,9 +382,10 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             // picAccessDenied
             // 
             this.picAccessDenied.Anchor = System.Windows.Forms.AnchorStyles.None;
-            this.picAccessDenied.Location = new System.Drawing.Point(25, 24);
+            this.picAccessDenied.Location = new System.Drawing.Point(38, 37);
+            this.picAccessDenied.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.picAccessDenied.Name = "picAccessDenied";
-            this.picAccessDenied.Size = new System.Drawing.Size(48, 48);
+            this.picAccessDenied.Size = new System.Drawing.Size(72, 74);
             this.picAccessDenied.TabIndex = 7;
             this.picAccessDenied.TabStop = false;
             this.picAccessDenied.Visible = false;
@@ -368,20 +395,23 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             this.txtSecureConfig.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtSecureConfig.Location = new System.Drawing.Point(6, 19);
+            this.txtSecureConfig.Location = new System.Drawing.Point(9, 29);
+            this.txtSecureConfig.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.txtSecureConfig.Multiline = true;
             this.txtSecureConfig.Name = "txtSecureConfig";
             this.txtSecureConfig.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-            this.txtSecureConfig.Size = new System.Drawing.Size(419, 142);
+            this.txtSecureConfig.Size = new System.Drawing.Size(626, 216);
             this.txtSecureConfig.TabIndex = 1;
             // 
             // grpMode
             // 
             this.grpMode.Controls.Add(this.radModeSync);
             this.grpMode.Controls.Add(this.radModeAsync);
-            this.grpMode.Location = new System.Drawing.Point(218, 247);
+            this.grpMode.Location = new System.Drawing.Point(327, 380);
+            this.grpMode.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.grpMode.Name = "grpMode";
-            this.grpMode.Size = new System.Drawing.Size(102, 65);
+            this.grpMode.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.grpMode.Size = new System.Drawing.Size(153, 100);
             this.grpMode.TabIndex = 3;
             this.grpMode.TabStop = false;
             this.grpMode.Text = "Execution Mode";
@@ -391,9 +421,10 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             this.radModeSync.AutoSize = true;
             this.radModeSync.Checked = true;
             this.radModeSync.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.radModeSync.Location = new System.Drawing.Point(6, 42);
+            this.radModeSync.Location = new System.Drawing.Point(9, 65);
+            this.radModeSync.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.radModeSync.Name = "radModeSync";
-            this.radModeSync.Size = new System.Drawing.Size(90, 17);
+            this.radModeSync.Size = new System.Drawing.Size(136, 24);
             this.radModeSync.TabIndex = 2;
             this.radModeSync.TabStop = true;
             this.radModeSync.Text = "Synchronous ";
@@ -404,9 +435,10 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             // radModeAsync
             // 
             this.radModeAsync.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.radModeAsync.Location = new System.Drawing.Point(6, 19);
+            this.radModeAsync.Location = new System.Drawing.Point(9, 29);
+            this.radModeAsync.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.radModeAsync.Name = "radModeAsync";
-            this.radModeAsync.Size = new System.Drawing.Size(94, 17);
+            this.radModeAsync.Size = new System.Drawing.Size(141, 26);
             this.radModeAsync.TabIndex = 0;
             this.radModeAsync.Text = "Asynchronous ";
             this.tipMain.SetToolTip(this.radModeAsync, "The triggering operation does not wait for the Plugin to complete to continue.");
@@ -417,9 +449,11 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             // 
             this.grpDeployment.Controls.Add(this.chkDeploymentOffline);
             this.grpDeployment.Controls.Add(this.chkDeploymentServer);
-            this.grpDeployment.Location = new System.Drawing.Point(326, 247);
+            this.grpDeployment.Location = new System.Drawing.Point(489, 380);
+            this.grpDeployment.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.grpDeployment.Name = "grpDeployment";
-            this.grpDeployment.Size = new System.Drawing.Size(88, 65);
+            this.grpDeployment.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.grpDeployment.Size = new System.Drawing.Size(132, 100);
             this.grpDeployment.TabIndex = 4;
             this.grpDeployment.TabStop = false;
             this.grpDeployment.Text = "Deployment";
@@ -428,9 +462,10 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             // 
             this.chkDeploymentOffline.AutoSize = true;
             this.chkDeploymentOffline.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.chkDeploymentOffline.Location = new System.Drawing.Point(6, 42);
+            this.chkDeploymentOffline.Location = new System.Drawing.Point(9, 65);
+            this.chkDeploymentOffline.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.chkDeploymentOffline.Name = "chkDeploymentOffline";
-            this.chkDeploymentOffline.Size = new System.Drawing.Size(56, 17);
+            this.chkDeploymentOffline.Size = new System.Drawing.Size(84, 24);
             this.chkDeploymentOffline.TabIndex = 3;
             this.chkDeploymentOffline.Text = "Offline";
             this.tipMain.SetToolTip(this.chkDeploymentOffline, "The Plugin will be downloaded and executed when the Outlook Client is Offline.");
@@ -442,9 +477,10 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             this.chkDeploymentServer.Checked = true;
             this.chkDeploymentServer.CheckState = System.Windows.Forms.CheckState.Checked;
             this.chkDeploymentServer.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.chkDeploymentServer.Location = new System.Drawing.Point(6, 19);
+            this.chkDeploymentServer.Location = new System.Drawing.Point(9, 29);
+            this.chkDeploymentServer.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.chkDeploymentServer.Name = "chkDeploymentServer";
-            this.chkDeploymentServer.Size = new System.Drawing.Size(57, 17);
+            this.chkDeploymentServer.Size = new System.Drawing.Size(84, 24);
             this.chkDeploymentServer.TabIndex = 0;
             this.chkDeploymentServer.Text = "Server";
             this.tipMain.SetToolTip(this.chkDeploymentServer, "The Plugin will trigger when the Outlook Client is Online.");
@@ -454,9 +490,11 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             // 
             this.grpInvocation.Controls.Add(this.radInvocationChild);
             this.grpInvocation.Controls.Add(this.radInvocationParent);
-            this.grpInvocation.Location = new System.Drawing.Point(218, 316);
+            this.grpInvocation.Location = new System.Drawing.Point(327, 486);
+            this.grpInvocation.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.grpInvocation.Name = "grpInvocation";
-            this.grpInvocation.Size = new System.Drawing.Size(196, 65);
+            this.grpInvocation.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.grpInvocation.Size = new System.Drawing.Size(294, 100);
             this.grpInvocation.TabIndex = 5;
             this.grpInvocation.TabStop = false;
             this.grpInvocation.Text = "Triggering Pipeline (CRM4 Only)";
@@ -466,9 +504,10 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             // 
             this.radInvocationChild.AutoSize = true;
             this.radInvocationChild.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.radInvocationChild.Location = new System.Drawing.Point(6, 42);
+            this.radInvocationChild.Location = new System.Drawing.Point(9, 65);
+            this.radInvocationChild.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.radInvocationChild.Name = "radInvocationChild";
-            this.radInvocationChild.Size = new System.Drawing.Size(88, 17);
+            this.radInvocationChild.Size = new System.Drawing.Size(136, 24);
             this.radInvocationChild.TabIndex = 4;
             this.radInvocationChild.Text = "Child Pipeline";
             this.tipMain.SetToolTip(this.radInvocationChild, "Example: Assigning an Account will Trigger on Update message for ownerid.");
@@ -482,9 +521,10 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             this.radInvocationParent.AutoSize = true;
             this.radInvocationParent.Checked = true;
             this.radInvocationParent.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.radInvocationParent.Location = new System.Drawing.Point(6, 19);
+            this.radInvocationParent.Location = new System.Drawing.Point(9, 29);
+            this.radInvocationParent.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.radInvocationParent.Name = "radInvocationParent";
-            this.radInvocationParent.Size = new System.Drawing.Size(96, 17);
+            this.radInvocationParent.Size = new System.Drawing.Size(147, 24);
             this.radInvocationParent.TabIndex = 0;
             this.radInvocationParent.TabStop = true;
             this.radInvocationParent.Text = "Parent Pipeline";
@@ -494,9 +534,10 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             // btnRegister
             // 
             this.btnRegister.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnRegister.Location = new System.Drawing.Point(708, 414);
+            this.btnRegister.Location = new System.Drawing.Point(1062, 637);
+            this.btnRegister.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.btnRegister.Name = "btnRegister";
-            this.btnRegister.Size = new System.Drawing.Size(113, 23);
+            this.btnRegister.Size = new System.Drawing.Size(170, 35);
             this.btnRegister.TabIndex = 1;
             this.btnRegister.Text = "&Register New Step";
             this.btnRegister.UseVisualStyleBackColor = true;
@@ -504,11 +545,12 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             // 
             // btnCancel
             // 
-            this.btnCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnCancel.Anchor = System.Windows.Forms.AnchorStyles.Right;
             this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.btnCancel.Location = new System.Drawing.Point(827, 414);
+            this.btnCancel.Location = new System.Drawing.Point(1240, 637);
+            this.btnCancel.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.btnCancel.Name = "btnCancel";
-            this.btnCancel.Size = new System.Drawing.Size(75, 23);
+            this.btnCancel.Size = new System.Drawing.Size(112, 35);
             this.btnCancel.TabIndex = 11;
             this.btnCancel.Text = "&Cancel";
             this.btnCancel.UseVisualStyleBackColor = true;
@@ -518,9 +560,10 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             // 
             this.radStagePreValidation.AutoSize = true;
             this.radStagePreValidation.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.radStagePreValidation.Location = new System.Drawing.Point(6, 19);
+            this.radStagePreValidation.Location = new System.Drawing.Point(9, 29);
+            this.radStagePreValidation.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.radStagePreValidation.Name = "radStagePreValidation";
-            this.radStagePreValidation.Size = new System.Drawing.Size(89, 17);
+            this.radStagePreValidation.Size = new System.Drawing.Size(136, 24);
             this.radStagePreValidation.TabIndex = 0;
             this.radStagePreValidation.Text = "Pre-validation";
             this.tipMain.SetToolTip(this.radStagePreValidation, "Executes before the triggering operation is executed.");
@@ -532,9 +575,10 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             | System.Windows.Forms.AnchorStyles.Right)));
             this.radStagePostOperationDeprecated.AutoSize = true;
             this.radStagePostOperationDeprecated.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.radStagePostOperationDeprecated.Location = new System.Drawing.Point(18, 358);
+            this.radStagePostOperationDeprecated.Location = new System.Drawing.Point(27, 551);
+            this.radStagePostOperationDeprecated.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.radStagePostOperationDeprecated.Name = "radStagePostOperationDeprecated";
-            this.radStagePostOperationDeprecated.Size = new System.Drawing.Size(156, 17);
+            this.radStagePostOperationDeprecated.Size = new System.Drawing.Size(246, 24);
             this.radStagePostOperationDeprecated.TabIndex = 3;
             this.radStagePostOperationDeprecated.Text = "Post-operation (CRM4 Only)";
             this.tipMain.SetToolTip(this.radStagePostOperationDeprecated, "Executes after the triggering operation has completed.");
@@ -545,9 +589,11 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             // 
             this.grpUnsecureConfig.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.grpUnsecureConfig.Controls.Add(this.txtUnsecureConfiguration);
-            this.grpUnsecureConfig.Location = new System.Drawing.Point(469, 103);
+            this.grpUnsecureConfig.Location = new System.Drawing.Point(704, 158);
+            this.grpUnsecureConfig.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.grpUnsecureConfig.Name = "grpUnsecureConfig";
-            this.grpUnsecureConfig.Size = new System.Drawing.Size(433, 129);
+            this.grpUnsecureConfig.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.grpUnsecureConfig.Size = new System.Drawing.Size(650, 198);
             this.grpUnsecureConfig.TabIndex = 8;
             this.grpUnsecureConfig.TabStop = false;
             this.grpUnsecureConfig.Text = "Unsecure Configuration";
@@ -558,20 +604,22 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             this.txtUnsecureConfiguration.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtUnsecureConfiguration.Location = new System.Drawing.Point(6, 19);
+            this.txtUnsecureConfiguration.Location = new System.Drawing.Point(9, 29);
+            this.txtUnsecureConfiguration.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.txtUnsecureConfiguration.Multiline = true;
             this.txtUnsecureConfiguration.Name = "txtUnsecureConfiguration";
             this.txtUnsecureConfiguration.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-            this.txtUnsecureConfiguration.Size = new System.Drawing.Size(419, 101);
+            this.txtUnsecureConfiguration.Size = new System.Drawing.Size(626, 153);
             this.txtUnsecureConfiguration.TabIndex = 1;
             // 
             // radStagePreOperation
             // 
             this.radStagePreOperation.AutoSize = true;
             this.radStagePreOperation.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.radStagePreOperation.Location = new System.Drawing.Point(6, 42);
+            this.radStagePreOperation.Location = new System.Drawing.Point(9, 65);
+            this.radStagePreOperation.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.radStagePreOperation.Name = "radStagePreOperation";
-            this.radStagePreOperation.Size = new System.Drawing.Size(88, 17);
+            this.radStagePreOperation.Size = new System.Drawing.Size(135, 24);
             this.radStagePreOperation.TabIndex = 1;
             this.radStagePreOperation.Text = "Pre-operation";
             this.tipMain.SetToolTip(this.radStagePreOperation, "Executes before the triggering operation is executed.");
@@ -582,9 +630,10 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             this.radStagePostOperation.AutoSize = true;
             this.radStagePostOperation.Checked = true;
             this.radStagePostOperation.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.radStagePostOperation.Location = new System.Drawing.Point(6, 65);
+            this.radStagePostOperation.Location = new System.Drawing.Point(9, 100);
+            this.radStagePostOperation.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.radStagePostOperation.Name = "radStagePostOperation";
-            this.radStagePostOperation.Size = new System.Drawing.Size(93, 17);
+            this.radStagePostOperation.Size = new System.Drawing.Size(143, 24);
             this.radStagePostOperation.TabIndex = 2;
             this.radStagePostOperation.TabStop = true;
             this.radStagePostOperation.Text = "Post-operation";
@@ -596,9 +645,11 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             this.grpStage.Controls.Add(this.radStagePostOperation);
             this.grpStage.Controls.Add(this.radStagePreOperation);
             this.grpStage.Controls.Add(this.radStagePreValidation);
-            this.grpStage.Location = new System.Drawing.Point(12, 247);
+            this.grpStage.Location = new System.Drawing.Point(18, 380);
+            this.grpStage.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.grpStage.Name = "grpStage";
-            this.grpStage.Size = new System.Drawing.Size(200, 92);
+            this.grpStage.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.grpStage.Size = new System.Drawing.Size(300, 142);
             this.grpStage.TabIndex = 2;
             this.grpStage.TabStop = false;
             this.grpStage.Text = "Eventing Pipeline Stage of Execution";
@@ -606,9 +657,10 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             // chkDeleteAsyncOperationIfSuccessful
             // 
             this.chkDeleteAsyncOperationIfSuccessful.Enabled = false;
-            this.chkDeleteAsyncOperationIfSuccessful.Location = new System.Drawing.Point(12, 392);
+            this.chkDeleteAsyncOperationIfSuccessful.Location = new System.Drawing.Point(18, 603);
+            this.chkDeleteAsyncOperationIfSuccessful.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.chkDeleteAsyncOperationIfSuccessful.Name = "chkDeleteAsyncOperationIfSuccessful";
-            this.chkDeleteAsyncOperationIfSuccessful.Size = new System.Drawing.Size(402, 16);
+            this.chkDeleteAsyncOperationIfSuccessful.Size = new System.Drawing.Size(603, 25);
             this.chkDeleteAsyncOperationIfSuccessful.TabIndex = 5;
             this.chkDeleteAsyncOperationIfSuccessful.Text = "Delete AsyncOperation if StatusCode = Successful";
             this.chkDeleteAsyncOperationIfSuccessful.UseVisualStyleBackColor = true;
@@ -618,9 +670,11 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             this.grpDescription.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.grpDescription.Controls.Add(this.txtDescription);
-            this.grpDescription.Location = new System.Drawing.Point(469, 13);
+            this.grpDescription.Location = new System.Drawing.Point(704, 20);
+            this.grpDescription.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.grpDescription.Name = "grpDescription";
-            this.grpDescription.Size = new System.Drawing.Size(433, 83);
+            this.grpDescription.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.grpDescription.Size = new System.Drawing.Size(650, 128);
             this.grpDescription.TabIndex = 6;
             this.grpDescription.TabStop = false;
             this.grpDescription.Text = "Description";
@@ -630,20 +684,31 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             this.txtDescription.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtDescription.Location = new System.Drawing.Point(4, 15);
+            this.txtDescription.Location = new System.Drawing.Point(6, 23);
+            this.txtDescription.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.txtDescription.Multiline = true;
             this.txtDescription.Name = "txtDescription";
             this.txtDescription.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-            this.txtDescription.Size = new System.Drawing.Size(423, 60);
+            this.txtDescription.Size = new System.Drawing.Size(632, 90);
             this.txtDescription.TabIndex = 1;
+            // 
+            // cmbWebhook
+            // 
+            this.cmbWebhook.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.cmbWebhook.FormattingEnabled = true;
+            this.cmbWebhook.Location = new System.Drawing.Point(190, 180);
+            this.cmbWebhook.Name = "cmbWebhook";
+            this.cmbWebhook.Size = new System.Drawing.Size(361, 28);
+            this.cmbWebhook.TabIndex = 19;
             // 
             // StepRegistrationForm
             // 
             this.AcceptButton = this.btnRegister;
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.btnCancel;
-            this.ClientSize = new System.Drawing.Size(907, 445);
+            this.ClientSize = new System.Drawing.Size(1360, 685);
             this.Controls.Add(this.grpDescription);
             this.Controls.Add(this.chkDeleteAsyncOperationIfSuccessful);
             this.Controls.Add(this.radStagePostOperationDeprecated);
@@ -657,9 +722,10 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             this.Controls.Add(this.grpSecureConfiguration);
             this.Controls.Add(this.grpGeneral);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
-            this.MinimumSize = new System.Drawing.Size(923, 484);
+            this.MinimumSize = new System.Drawing.Size(1374, 714);
             this.Name = "StepRegistrationForm";
             this.ShowIcon = false;
             this.ShowInTaskbar = false;
@@ -737,7 +803,7 @@ namespace Xrm.Sdk.PluginRegistration.Forms
         private System.Windows.Forms.LinkLabel lnkInvalidSecureConfigurationId;
         private System.Windows.Forms.Label lblInvalidSecureConfigurationId;
         private System.Windows.Forms.PictureBox picInvalidSecureConfigurationId;
-        private System.Windows.Forms.ComboBox cmbServiceEndpoint;        
-
+        private System.Windows.Forms.ComboBox cmbServiceEndpoint;
+        private System.Windows.Forms.ComboBox cmbWebhook;
     }
 }

--- a/Xrm.Sdk.PluginRegistration/Forms/WebHookRegistrationForm.Designer.cs
+++ b/Xrm.Sdk.PluginRegistration/Forms/WebHookRegistrationForm.Designer.cs
@@ -1,0 +1,210 @@
+﻿namespace Xrm.Sdk.PluginRegistration.Forms
+{
+    partial class WebHookRegistrationForm
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.lblName = new System.Windows.Forms.Label();
+            this.txtName = new System.Windows.Forms.TextBox();
+            this.txtEndpointUrl = new System.Windows.Forms.TextBox();
+            this.lblEndpointUrl = new System.Windows.Forms.Label();
+            this.lblAuth = new System.Windows.Forms.Label();
+            this.cmbAuth = new System.Windows.Forms.ComboBox();
+            this.lblValue = new System.Windows.Forms.Label();
+            this.txtValue = new System.Windows.Forms.TextBox();
+            this.btnSave = new System.Windows.Forms.Button();
+            this.btnCancel = new System.Windows.Forms.Button();
+            this.dgvKeyValue = new System.Windows.Forms.DataGridView();
+            this.Keys = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.Values = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            ((System.ComponentModel.ISupportInitialize)(this.dgvKeyValue)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // lblName
+            // 
+            this.lblName.AutoSize = true;
+            this.lblName.Location = new System.Drawing.Point(12, 23);
+            this.lblName.Name = "lblName";
+            this.lblName.Size = new System.Drawing.Size(51, 20);
+            this.lblName.TabIndex = 0;
+            this.lblName.Text = "Name";
+            // 
+            // txtName
+            // 
+            this.txtName.Location = new System.Drawing.Point(161, 20);
+            this.txtName.Name = "txtName";
+            this.txtName.Size = new System.Drawing.Size(627, 26);
+            this.txtName.TabIndex = 1;
+            // 
+            // txtEndpointUrl
+            // 
+            this.txtEndpointUrl.Location = new System.Drawing.Point(161, 71);
+            this.txtEndpointUrl.Name = "txtEndpointUrl";
+            this.txtEndpointUrl.Size = new System.Drawing.Size(627, 26);
+            this.txtEndpointUrl.TabIndex = 3;
+            // 
+            // lblEndpointUrl
+            // 
+            this.lblEndpointUrl.AutoSize = true;
+            this.lblEndpointUrl.Location = new System.Drawing.Point(12, 74);
+            this.lblEndpointUrl.Name = "lblEndpointUrl";
+            this.lblEndpointUrl.Size = new System.Drawing.Size(110, 20);
+            this.lblEndpointUrl.TabIndex = 2;
+            this.lblEndpointUrl.Text = "Endpoint URL";
+            // 
+            // lblAuth
+            // 
+            this.lblAuth.AutoSize = true;
+            this.lblAuth.Location = new System.Drawing.Point(12, 128);
+            this.lblAuth.Name = "lblAuth";
+            this.lblAuth.Size = new System.Drawing.Size(112, 20);
+            this.lblAuth.TabIndex = 4;
+            this.lblAuth.Text = "Authentication";
+            // 
+            // cmbAuth
+            // 
+            this.cmbAuth.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbAuth.FormattingEnabled = true;
+            this.cmbAuth.Items.AddRange(new object[] {
+            "HttpHeader",
+            "WebhookKey",
+            "HttpQueryString"});
+            this.cmbAuth.Location = new System.Drawing.Point(161, 125);
+            this.cmbAuth.Name = "cmbAuth";
+            this.cmbAuth.Size = new System.Drawing.Size(627, 28);
+            this.cmbAuth.TabIndex = 5;
+            this.cmbAuth.SelectedIndexChanged += new System.EventHandler(this.cmbAuth_SelectedIndexChanged);
+            // 
+            // lblValue
+            // 
+            this.lblValue.AutoSize = true;
+            this.lblValue.Location = new System.Drawing.Point(12, 186);
+            this.lblValue.Name = "lblValue";
+            this.lblValue.Size = new System.Drawing.Size(50, 20);
+            this.lblValue.TabIndex = 6;
+            this.lblValue.Text = "Value";
+            // 
+            // txtValue
+            // 
+            this.txtValue.Location = new System.Drawing.Point(161, 183);
+            this.txtValue.Name = "txtValue";
+            this.txtValue.Size = new System.Drawing.Size(627, 26);
+            this.txtValue.TabIndex = 7;
+            // 
+            // btnSave
+            // 
+            this.btnSave.Location = new System.Drawing.Point(598, 401);
+            this.btnSave.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.btnSave.Name = "btnSave";
+            this.btnSave.Size = new System.Drawing.Size(91, 35);
+            this.btnSave.TabIndex = 8;
+            this.btnSave.Text = "Save";
+            this.btnSave.UseVisualStyleBackColor = true;
+            this.btnSave.Click += new System.EventHandler(this.btnSave_Click);
+            // 
+            // btnCancel
+            // 
+            this.btnCancel.Location = new System.Drawing.Point(697, 401);
+            this.btnCancel.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.btnCancel.Name = "btnCancel";
+            this.btnCancel.Size = new System.Drawing.Size(91, 35);
+            this.btnCancel.TabIndex = 9;
+            this.btnCancel.Text = "Cancel";
+            this.btnCancel.UseVisualStyleBackColor = true;
+            this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
+            // 
+            // dgvKeyValue
+            // 
+            this.dgvKeyValue.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.Fill;
+            this.dgvKeyValue.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.dgvKeyValue.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
+            this.Keys,
+            this.Values});
+            this.dgvKeyValue.Location = new System.Drawing.Point(16, 182);
+            this.dgvKeyValue.Name = "dgvKeyValue";
+            this.dgvKeyValue.RowHeadersWidth = 62;
+            this.dgvKeyValue.RowTemplate.Height = 28;
+            this.dgvKeyValue.Size = new System.Drawing.Size(772, 211);
+            this.dgvKeyValue.TabIndex = 10;
+            // 
+            // Keys
+            // 
+            this.Keys.HeaderText = "Keys";
+            this.Keys.MinimumWidth = 8;
+            this.Keys.Name = "Keys";
+            // 
+            // Values
+            // 
+            this.Values.HeaderText = "Values";
+            this.Values.MinimumWidth = 8;
+            this.Values.Name = "Values";
+            // 
+            // WebHookRegistrationForm
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(800, 450);
+            this.Controls.Add(this.dgvKeyValue);
+            this.Controls.Add(this.btnCancel);
+            this.Controls.Add(this.btnSave);
+            this.Controls.Add(this.txtValue);
+            this.Controls.Add(this.lblValue);
+            this.Controls.Add(this.cmbAuth);
+            this.Controls.Add(this.lblAuth);
+            this.Controls.Add(this.txtEndpointUrl);
+            this.Controls.Add(this.lblEndpointUrl);
+            this.Controls.Add(this.txtName);
+            this.Controls.Add(this.lblName);
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "WebHookRegistrationForm";
+            this.ShowIcon = false;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "WebHook Registration";
+            ((System.ComponentModel.ISupportInitialize)(this.dgvKeyValue)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label lblName;
+        private System.Windows.Forms.TextBox txtName;
+        private System.Windows.Forms.TextBox txtEndpointUrl;
+        private System.Windows.Forms.Label lblEndpointUrl;
+        private System.Windows.Forms.Label lblAuth;
+        private System.Windows.Forms.ComboBox cmbAuth;
+        private System.Windows.Forms.Label lblValue;
+        private System.Windows.Forms.TextBox txtValue;
+        private System.Windows.Forms.Button btnSave;
+        private System.Windows.Forms.Button btnCancel;
+        private System.Windows.Forms.DataGridView dgvKeyValue;
+        private System.Windows.Forms.DataGridViewTextBoxColumn Keys;
+        private System.Windows.Forms.DataGridViewTextBoxColumn Values;
+    }
+}

--- a/Xrm.Sdk.PluginRegistration/Forms/WebHookRegistrationForm.cs
+++ b/Xrm.Sdk.PluginRegistration/Forms/WebHookRegistrationForm.cs
@@ -1,0 +1,174 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Windows.Forms;
+using Xrm.Sdk.PluginRegistration.Helpers;
+using Xrm.Sdk.PluginRegistration.Wrappers;
+using XrmToolBox.Extensibility;
+
+namespace Xrm.Sdk.PluginRegistration.Forms
+{
+    public partial class WebHookRegistrationForm : Form
+    {
+        private CrmOrganization m_org;
+        private CrmServiceEndpoint m_webhook;
+        private MainControl m_orgControl;
+
+        public WebHookRegistrationForm(CrmOrganization org, MainControl orgControl, CrmServiceEndpoint webhook)
+        {
+            m_org = org ?? throw new ArgumentNullException("org");
+            m_webhook = webhook;
+            m_orgControl = orgControl;
+
+            InitializeComponent();
+
+            if (m_webhook != null)
+            {
+                txtName.Text = m_webhook.Name;
+                txtEndpointUrl.Text = m_webhook.Url;
+                cmbAuth.SelectedItem = m_webhook.AuthType.ToString();
+            }
+            else
+            {
+                cmbAuth.SelectedItem = CrmServiceEndpointAuthType.HttpHeader.ToString();
+            }
+        }
+
+        private void btnCancel_Click(object sender, EventArgs e)
+        {
+            Close();
+        }
+
+        private void cmbAuth_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            var selectedAuthMethod = (string)cmbAuth.SelectedItem;
+
+            if (selectedAuthMethod == "WebhookKey")
+            {
+                lblValue.Visible = true;
+                txtValue.Visible = true;
+                dgvKeyValue.Visible = false;
+
+                dgvKeyValue.Rows.Clear();
+            }
+            else
+            {
+                lblValue.Visible = false;
+                txtValue.Visible = false;
+                dgvKeyValue.Visible = true;
+
+                txtValue.Text = string.Empty;
+            }
+        }
+
+        private void btnSave_Click(object sender, EventArgs e)
+        {
+            var errorMsgs = new List<string>();
+
+            if (txtName.Text == string.Empty)
+            {
+                errorMsgs.Add("Endpoint Name is required");
+            }
+            
+            if(txtEndpointUrl.Text == string.Empty)
+            {
+                errorMsgs.Add("Endpoint URL is required");
+            }
+            else
+            {
+                var isValid = Uri.TryCreate(txtEndpointUrl.Text, UriKind.Absolute, out _);
+                if (!isValid)
+                {
+                    errorMsgs.Add("Endpoint URL should be valid.");
+                }
+            }
+
+            var authValue = GenerateAuthValue();
+
+            if (errorMsgs.Count == 0 && authValue == string.Empty)
+            {
+                errorMsgs.Add("Auth Value is required.");
+            }
+
+            if (errorMsgs.Count == 0)
+            {
+                UpsertWebhook();
+            }
+            else
+            {
+                MessageBox.Show(string.Join(Environment.NewLine,errorMsgs),
+                    "Invalid configuration",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Warning);
+            }
+
+        }
+
+        private void UpsertWebhook()
+        {
+            var authValue = GenerateAuthValue();
+
+            var webhook = new CrmServiceEndpoint(m_org)
+            {
+                Url = txtEndpointUrl.Text,
+                Name = txtName.Text,
+                AuthType = (CrmServiceEndpointAuthType)Enum.Parse(typeof(CrmServiceEndpointAuthType),
+                    cmbAuth.SelectedItem.ToString(), true),
+                ServiceEndpointId = m_webhook?.ServiceEndpointId ?? Guid.Empty,
+                AuthValue = authValue,
+                ConnectionMode = CrmServiceEndpointConnectionMode.Normal,
+                Contract = CrmServiceEndpointContract.Webhook,
+                UserClaim = CrmServiceEndpointUserClaim.None
+            };
+
+            Close();
+
+            var isNew = webhook.ServiceEndpointId == Guid.Empty;
+
+            m_orgControl.WorkAsync(new WorkAsyncInfo($"{(isNew ? "Creating" : "Updating")} webhook...",
+                (eventargs) => {
+                    if (isNew)
+                    {
+                        RegistrationHelper.RegisterWebHook(m_org, webhook);
+                    }
+                    else
+                    {
+                        RegistrationHelper.UpdatewebHook(m_org, webhook);
+                    }
+                })
+            {
+                PostWorkCallBack = (completedargs) => {
+                    if (completedargs.Error == null)
+                    {
+                        m_orgControl.RefreshFullTreeView();
+                    }
+                    else
+                    {
+                        MessageBox.Show(completedargs.Error.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    }
+                }
+            });
+        }
+
+        private string GenerateAuthValue()
+        {
+            return txtValue.Text != string.Empty ? txtValue.Text : GenerateKeyValueXml();
+        }
+
+        private string GenerateKeyValueXml()
+        {
+            var settingStrings = string.Empty;
+
+            foreach (DataGridViewRow row in dgvKeyValue.Rows)
+            {
+                var key = row.Cells[0].Value?.ToString();
+                var value = row.Cells[1].Value?.ToString();
+
+                if(key == null && value == null){continue;}
+
+                settingStrings += $"<setting name='{key}' value='{value}' />";
+            }
+
+            return settingStrings != string.Empty ? $@"<settings>{settingStrings}</settings>" : string.Empty;
+        }
+    }
+}

--- a/Xrm.Sdk.PluginRegistration/Forms/WebHookRegistrationForm.resx
+++ b/Xrm.Sdk.PluginRegistration/Forms/WebHookRegistrationForm.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -117,13 +117,16 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="tipMain.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
+  <metadata name="Keys.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
   </metadata>
-  <metadata name="tipMain.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
+  <metadata name="Values.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
   </metadata>
-  <data name="grpUnsecureConfig.ToolTip" xml:space="preserve">
-    <value>Passed as the first parameter to the Plugin's Constructor when it has 1 or 2 string input parameters. This configuration value is downloaded to the user's computer when they go offline making it unsecure.</value>
-  </data>
+  <metadata name="Keys.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="Values.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
 </root>

--- a/Xrm.Sdk.PluginRegistration/Helpers/OrganizationHelper.cs
+++ b/Xrm.Sdk.PluginRegistration/Helpers/OrganizationHelper.cs
@@ -392,6 +392,8 @@ namespace Xrm.Sdk.PluginRegistration.Helpers
                 EntityName = ServiceEndpoint.EntityLogicalName
             };
 
+            query.Criteria.AddCondition("contract", ConditionOperator.NotEqual, 8);
+
             //Clear the Service Endpoints list since we are reloading from scratch
             org.ClearServiceEndpoints();
 
@@ -400,6 +402,36 @@ namespace Xrm.Sdk.PluginRegistration.Helpers
                 org.AddServiceEndpoint(new CrmServiceEndpoint(org, serviceEndPoint));
             }
         }
+
+        public static void LoadWebhooks(CrmOrganization org, ref Dictionary<Guid, ICrmEntity> typeList)
+        {
+            if (org == null)
+            {
+                throw new ArgumentNullException("org");
+            }
+
+            QueryExpression query = new QueryExpression
+            {
+                ColumnSet = GetColumnSet(ServiceEndpoint.EntityLogicalName),
+                Criteria = new FilterExpression(),
+                EntityName = ServiceEndpoint.EntityLogicalName
+            };
+
+            query.Criteria.AddCondition("contract", ConditionOperator.Equal, 8);
+
+            //Clear the Service Endpoints list since we are reloading from scratch
+            org.ClearWebhooks();
+
+            foreach (var serviceEndPoint in org.OrganizationService.RetrieveMultipleAllPages(query).Entities.Select(x => Magic.CastTo<ServiceEndpoint>(x)))
+            {
+                var crmWebhook = new CrmServiceEndpoint(org, serviceEndPoint);
+                org.AddWebhook(crmWebhook);
+
+                typeList.Add(crmWebhook.EntityId, crmWebhook);
+            }
+        }
+
+
 
         /// <summary>
         /// Initializes any items that need to be initialized when the connection gets opened
@@ -473,8 +505,8 @@ namespace Xrm.Sdk.PluginRegistration.Helpers
                 {
                     prog.Increment("Loading Plugins");
                 }
-                Dictionary<Guid, CrmPlugin> typeList;
-                LoadPlugins(org, out typeList);
+
+                LoadPlugins(org, out var typeList);
 
                 //Initialize list of service end points
                 if (prog != null)
@@ -482,6 +514,13 @@ namespace Xrm.Sdk.PluginRegistration.Helpers
                     prog.Increment("Loading Service Endpoints");
                 }
                 LoadServiceEndpoints(org);
+
+                //Initialize list of webhooks
+                if (prog != null)
+                {
+                    prog.Increment("Loading Webhooks");
+                }
+                LoadWebhooks(org, ref typeList);
 
                 //Initialize list of steps
                 if (prog != null)
@@ -812,7 +851,9 @@ namespace Xrm.Sdk.PluginRegistration.Helpers
                             "userclaim",
                             "solutionnamespace",
                             "connectionmode",
-                            "description");
+                            "description",
+                            "url",
+                            "authtype");
                         break;
 
                     case PluginAssembly.EntityLogicalName:
@@ -1021,7 +1062,7 @@ namespace Xrm.Sdk.PluginRegistration.Helpers
             }
         }
 
-        private static void LoadPlugins(CrmOrganization org, out Dictionary<Guid, CrmPlugin> typeList)
+        private static void LoadPlugins(CrmOrganization org, out Dictionary<Guid, ICrmEntity> typeList)
         {
             if (org == null)
             {
@@ -1054,7 +1095,7 @@ namespace Xrm.Sdk.PluginRegistration.Helpers
 
             //Initialize the map
             bool profilerPluginLocated = false;//!OrganizationHelper.IsProfilerSupported;
-            typeList = new Dictionary<Guid, CrmPlugin>();
+            typeList = new Dictionary<Guid, ICrmEntity>();
 
             foreach (var plugin in results.Entities.Select(x => Magic.CastTo<PluginType>(x)))
             {
@@ -1086,7 +1127,7 @@ namespace Xrm.Sdk.PluginRegistration.Helpers
             }
         }
 
-        private static void LoadSteps(CrmOrganization org, Dictionary<Guid, CrmPlugin> typeList, out Dictionary<Guid, CrmPluginStep> crmStepList)
+        private static void LoadSteps(CrmOrganization org, Dictionary<Guid, ICrmEntity> typeList, out Dictionary<Guid, CrmPluginStep> crmStepList)
         {
             if (org == null)
             {
@@ -1154,56 +1195,63 @@ namespace Xrm.Sdk.PluginRegistration.Helpers
                 var secureConfig = step.GetAttributeValue<AliasedValue>(SecureConfigurationAttributeName);
 
                 //Check if the secure configuration was retrieved
-                bool invalidSecureConfigurationId = false;
-                if (null != step.SdkMessageProcessingStepSecureConfigId && null == secureConfig &&
-                    !org.SecureConfigurationPermissionDenied)
-                {
-                    invalidSecureConfigurationId = true;
-                }
+                bool invalidSecureConfigurationId = null != step.SdkMessageProcessingStepSecureConfigId && null == secureConfig &&
+                                                    !org.SecureConfigurationPermissionDenied;
 
                 //Retrieve the secure configuration
-                string secureConfiguration = (null == secureConfig ? null : (string)secureConfig.Value);
+                string secureConfiguration = (string) secureConfig?.Value;
 
                 //Retrieve the plug-in
 #pragma warning disable 0612
-                Guid pluginId = (step.PluginTypeId != null) ? step.PluginTypeId.Id : Guid.Empty;
+                Guid pluginId = step.PluginTypeId?.Id ?? Guid.Empty;
 #pragma warning restore 0612
+                var webhookId = step.EventHandler?.Id ?? Guid.Empty;
 
-                CrmPlugin plugin;
-                if (null != typeList && typeList.TryGetValue(pluginId, out plugin))
+                switch (step.EventHandler.LogicalName)
                 {
-                    CrmPluginStep crmStep;
-                    if (plugin.Steps.TryGetValue(step.SdkMessageProcessingStepId.GetValueOrDefault(), out crmStep))
-                    {
-                        crmStep.RefreshFromSdkMessageProcessingStep(plugin.AssemblyId, step, secureConfiguration);
-                    }
-                    else
-                    {
-                        crmStep = new CrmPluginStep(org, plugin.AssemblyId, step, secureConfiguration);
-                        plugin.AddStep(crmStep);
-                    }
+                    case "serviceendpoint":
+                        if (typeList == null || !typeList.TryGetValue(webhookId, out var webhook)) continue;
 
-                    if (plugin.IsProfilerPlugin)
-                    {
-                        // ProfilerConfiguration configuration = RetrieveProfilerConfiguration(crmStep);
-                        //if (null != configuration)
-                        //{
-                        //    EntityReference profiledHandler = configuration.EventHandler;
-                        //    if (configuration.IsContextReplay.GetValueOrDefault())
-                        //    {
-                        //        crmStep.ProfilerStepId = crmStep.StepId;
-                        //    }
-                        //    else if (null != profiledHandler && !profiledStepList.ContainsKey(profiledHandler.Id))
-                        //    {
-                        //        profiledStepList[profiledHandler.Id] = crmStep;
-                        //        crmStep.ProfilerOriginalStepId = profiledHandler.Id;
-                        //    }
-                        //}
-                    }
+                        var crmWebhook = (CrmServiceEndpoint)webhook;
 
-                    crmStep.SecureConfigurationRecordIdInvalid = invalidSecureConfigurationId;
+                        if (crmWebhook.Steps.TryGetValue(step.SdkMessageProcessingStepId.GetValueOrDefault(), out var crmStep1))
+                        {
+                            crmStep1.RefreshFromSdkMessageProcessingStep(crmWebhook.ServiceEndpointId, step, secureConfiguration);
+                        }
+                        else
+                        {
+                            crmStep1 = new CrmPluginStep(org, crmWebhook.ServiceEndpointId, step, secureConfiguration);
+                            crmWebhook.AddStep(crmStep1);
+                        }
 
-                    crmStepList.Add(step.SdkMessageProcessingStepId.Value, plugin.Steps[step.SdkMessageProcessingStepId.Value]);
+                        crmStep1.SecureConfigurationRecordIdInvalid = invalidSecureConfigurationId;
+
+                        crmStepList.Add(step.SdkMessageProcessingStepId.Value, crmStep1);
+
+                        continue;
+                    default:
+                        if (typeList == null || !typeList.TryGetValue(pluginId, out var plugin)) continue;
+
+                        var crmPlugin = (CrmPlugin)plugin;
+                        if (crmPlugin.Steps.TryGetValue(step.SdkMessageProcessingStepId.GetValueOrDefault(), out var crmStep))
+                        {
+                            crmStep.RefreshFromSdkMessageProcessingStep(crmPlugin.AssemblyId, step, secureConfiguration);
+                        }
+                        else
+                        {
+                            crmStep = new CrmPluginStep(org, crmPlugin.AssemblyId, step, secureConfiguration);
+                            crmPlugin.AddStep(crmStep);
+                        }
+
+                        if (crmPlugin.IsProfilerPlugin)
+                        {
+
+                        }
+
+                        crmStep.SecureConfigurationRecordIdInvalid = invalidSecureConfigurationId;
+
+                        crmStepList.Add(step.SdkMessageProcessingStepId.Value, crmPlugin.Steps[step.SdkMessageProcessingStepId.Value]);
+                        continue;
                 }
             }
 

--- a/Xrm.Sdk.PluginRegistration/Helpers/RegistrationHelper.cs
+++ b/Xrm.Sdk.PluginRegistration/Helpers/RegistrationHelper.cs
@@ -247,6 +247,22 @@ namespace Xrm.Sdk.PluginRegistration.Helpers
             return org.OrganizationService.Create(sep);
         }
 
+        public static Guid RegisterWebHook(CrmOrganization org, CrmServiceEndpoint webhook)
+        {
+            if (org == null)
+            {
+                throw new ArgumentNullException("org");
+            }
+            else if (webhook == null)
+            {
+                throw new ArgumentNullException("webhook");
+            }
+
+            ServiceEndpoint wh = webhook.GenerateCrmEntities()[ServiceEndpoint.EntityLogicalName] as ServiceEndpoint;
+
+            return org.OrganizationService.Create(wh);
+        }
+
         public static Guid RegisterStep(CrmOrganization org, CrmPluginStep step)
         {
             if (org == null)
@@ -859,6 +875,24 @@ namespace Xrm.Sdk.PluginRegistration.Helpers
             //PluginAssembly pt1 = new PluginAssembly();
             pt1.Description = description;
             org.OrganizationService.Update(pt1);
+        }
+
+        public static void UpdatewebHook(CrmOrganization org, CrmServiceEndpoint webhook)
+        {
+            if (org == null)
+            {
+                throw new ArgumentNullException("org");
+            }
+            else if (webhook.ServiceEndpointId == Guid.Empty)
+            {
+                throw new ArgumentNullException("webhookId");
+            }
+
+            var wh = (ServiceEndpoint)webhook.GenerateCrmEntities()[ServiceEndpoint.EntityLogicalName];
+
+            // Work around as updating only description is failing with publickeytoken not null
+            org.OrganizationService.Update(wh);
+            OrganizationHelper.RefreshServiceEndpoint(org, webhook);
         }
 
         public static void UpdateImage(CrmOrganization org, CrmPluginImage image)

--- a/Xrm.Sdk.PluginRegistration/MainControl.Designer.cs
+++ b/Xrm.Sdk.PluginRegistration/MainControl.Designer.cs
@@ -78,6 +78,7 @@ namespace Xrm.Sdk.PluginRegistration
             this.trvPlugins = new Xrm.Sdk.PluginRegistration.Controls.CrmTreeControl();
             this.btnSave = new System.Windows.Forms.Button();
             this.propGridEntity = new System.Windows.Forms.PropertyGrid();
+            this.toolWebHookRegister = new System.Windows.Forms.ToolStripMenuItem();
             this.mnuContextNode.SuspendLayout();
             this.mnuContextGeneral.SuspendLayout();
             this.grpGrid.SuspendLayout();
@@ -92,6 +93,7 @@ namespace Xrm.Sdk.PluginRegistration
             // 
             // mnuContextNode
             // 
+            this.mnuContextNode.ImageScalingSize = new System.Drawing.Size(24, 24);
             this.mnuContextNode.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.mnuContextNodeAssemblyRegister,
             this.mnuContextNodeStepRegister,
@@ -104,64 +106,64 @@ namespace Xrm.Sdk.PluginRegistration
             this.mnuContextNodeUpdate,
             this.mnuContextNodeUnregister});
             this.mnuContextNode.Name = "mnuContextNode";
-            this.mnuContextNode.Size = new System.Drawing.Size(198, 192);
+            this.mnuContextNode.Size = new System.Drawing.Size(270, 272);
             // 
             // mnuContextNodeAssemblyRegister
             // 
             this.mnuContextNodeAssemblyRegister.Name = "mnuContextNodeAssemblyRegister";
-            this.mnuContextNodeAssemblyRegister.Size = new System.Drawing.Size(197, 22);
+            this.mnuContextNodeAssemblyRegister.Size = new System.Drawing.Size(269, 32);
             this.mnuContextNodeAssemblyRegister.Text = "Register New &Assembly";
             this.mnuContextNodeAssemblyRegister.Click += new System.EventHandler(this.toolAssemblyRegister_Click);
             // 
             // mnuContextNodeStepRegister
             // 
             this.mnuContextNodeStepRegister.Name = "mnuContextNodeStepRegister";
-            this.mnuContextNodeStepRegister.Size = new System.Drawing.Size(197, 22);
+            this.mnuContextNodeStepRegister.Size = new System.Drawing.Size(269, 32);
             this.mnuContextNodeStepRegister.Text = "Register New S&tep";
             this.mnuContextNodeStepRegister.Click += new System.EventHandler(this.toolStepRegister_Click);
             // 
             // mnuContextNodeImageRegister
             // 
             this.mnuContextNodeImageRegister.Name = "mnuContextNodeImageRegister";
-            this.mnuContextNodeImageRegister.Size = new System.Drawing.Size(197, 22);
+            this.mnuContextNodeImageRegister.Size = new System.Drawing.Size(269, 32);
             this.mnuContextNodeImageRegister.Text = "Register New &Image";
             this.mnuContextNodeImageRegister.Click += new System.EventHandler(this.toolImageRegister_Click);
             // 
             // mnuContextNodeSep1
             // 
             this.mnuContextNodeSep1.Name = "mnuContextNodeSep1";
-            this.mnuContextNodeSep1.Size = new System.Drawing.Size(194, 6);
+            this.mnuContextNodeSep1.Size = new System.Drawing.Size(266, 6);
             // 
             // mnuContextNodeSearch
             // 
             this.mnuContextNodeSearch.Name = "mnuContextNodeSearch";
-            this.mnuContextNodeSearch.Size = new System.Drawing.Size(197, 22);
+            this.mnuContextNodeSearch.Size = new System.Drawing.Size(269, 32);
             this.mnuContextNodeSearch.Text = "&Search";
             this.mnuContextNodeSearch.Click += new System.EventHandler(this.toolSearch_Click);
             // 
             // mnuContextNodeRefresh
             // 
             this.mnuContextNodeRefresh.Name = "mnuContextNodeRefresh";
-            this.mnuContextNodeRefresh.Size = new System.Drawing.Size(197, 22);
+            this.mnuContextNodeRefresh.Size = new System.Drawing.Size(269, 32);
             this.mnuContextNodeRefresh.Text = "Re&fresh";
             this.mnuContextNodeRefresh.Click += new System.EventHandler(this.toolRefresh_Click);
             // 
             // mnuContextNodeSep2
             // 
             this.mnuContextNodeSep2.Name = "mnuContextNodeSep2";
-            this.mnuContextNodeSep2.Size = new System.Drawing.Size(194, 6);
+            this.mnuContextNodeSep2.Size = new System.Drawing.Size(266, 6);
             // 
             // mnuContextNodeEnable
             // 
             this.mnuContextNodeEnable.Name = "mnuContextNodeEnable";
-            this.mnuContextNodeEnable.Size = new System.Drawing.Size(197, 22);
+            this.mnuContextNodeEnable.Size = new System.Drawing.Size(269, 32);
             this.mnuContextNodeEnable.Text = "&Disable";
             this.mnuContextNodeEnable.Click += new System.EventHandler(this.toolEnable_Click);
             // 
             // mnuContextNodeUpdate
             // 
             this.mnuContextNodeUpdate.Name = "mnuContextNodeUpdate";
-            this.mnuContextNodeUpdate.Size = new System.Drawing.Size(197, 22);
+            this.mnuContextNodeUpdate.Size = new System.Drawing.Size(269, 32);
             this.mnuContextNodeUpdate.Text = "&Update";
             this.mnuContextNodeUpdate.Click += new System.EventHandler(this.toolUpdate_Click);
             // 
@@ -169,12 +171,13 @@ namespace Xrm.Sdk.PluginRegistration
             // 
             this.mnuContextNodeUnregister.Name = "mnuContextNodeUnregister";
             this.mnuContextNodeUnregister.ShortcutKeyDisplayString = "Delete";
-            this.mnuContextNodeUnregister.Size = new System.Drawing.Size(197, 22);
+            this.mnuContextNodeUnregister.Size = new System.Drawing.Size(269, 32);
             this.mnuContextNodeUnregister.Text = "U&nregister";
             this.mnuContextNodeUnregister.Click += new System.EventHandler(this.toolUnregister_Click);
             // 
             // mnuContextGeneral
             // 
+            this.mnuContextGeneral.ImageScalingSize = new System.Drawing.Size(24, 24);
             this.mnuContextGeneral.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.mnuContextGeneralAssemblyRegister,
             this.mnuContextGeneralStepRegister,
@@ -183,39 +186,39 @@ namespace Xrm.Sdk.PluginRegistration
             this.mnuContextGeneralRefresh,
             this.mnuContextGeneralSearch});
             this.mnuContextGeneral.Name = "mnuContextTree";
-            this.mnuContextGeneral.Size = new System.Drawing.Size(198, 120);
+            this.mnuContextGeneral.Size = new System.Drawing.Size(270, 170);
             // 
             // mnuContextGeneralAssemblyRegister
             // 
             this.mnuContextGeneralAssemblyRegister.Name = "mnuContextGeneralAssemblyRegister";
-            this.mnuContextGeneralAssemblyRegister.Size = new System.Drawing.Size(197, 22);
+            this.mnuContextGeneralAssemblyRegister.Size = new System.Drawing.Size(269, 32);
             this.mnuContextGeneralAssemblyRegister.Text = "Register New &Assembly";
             this.mnuContextGeneralAssemblyRegister.Click += new System.EventHandler(this.toolAssemblyRegister_Click);
             // 
             // mnuContextGeneralStepRegister
             // 
             this.mnuContextGeneralStepRegister.Name = "mnuContextGeneralStepRegister";
-            this.mnuContextGeneralStepRegister.Size = new System.Drawing.Size(197, 22);
+            this.mnuContextGeneralStepRegister.Size = new System.Drawing.Size(269, 32);
             this.mnuContextGeneralStepRegister.Text = "Register New S&tep";
             this.mnuContextGeneralStepRegister.Click += new System.EventHandler(this.toolStepRegister_Click);
             // 
             // mnuContextGeneralImageRegister
             // 
             this.mnuContextGeneralImageRegister.Name = "mnuContextGeneralImageRegister";
-            this.mnuContextGeneralImageRegister.Size = new System.Drawing.Size(197, 22);
+            this.mnuContextGeneralImageRegister.Size = new System.Drawing.Size(269, 32);
             this.mnuContextGeneralImageRegister.Text = "Register New &Image";
             this.mnuContextGeneralImageRegister.Click += new System.EventHandler(this.toolImageRegister_Click);
             // 
             // mnuContextGeneralSep1
             // 
             this.mnuContextGeneralSep1.Name = "mnuContextGeneralSep1";
-            this.mnuContextGeneralSep1.Size = new System.Drawing.Size(194, 6);
+            this.mnuContextGeneralSep1.Size = new System.Drawing.Size(266, 6);
             // 
             // mnuContextGeneralRefresh
             // 
             this.mnuContextGeneralRefresh.Name = "mnuContextGeneralRefresh";
             this.mnuContextGeneralRefresh.ShortcutKeyDisplayString = "F5";
-            this.mnuContextGeneralRefresh.Size = new System.Drawing.Size(197, 22);
+            this.mnuContextGeneralRefresh.Size = new System.Drawing.Size(269, 32);
             this.mnuContextGeneralRefresh.Text = "Re&fresh";
             this.mnuContextGeneralRefresh.Click += new System.EventHandler(this.toolRefresh_Click);
             // 
@@ -223,7 +226,7 @@ namespace Xrm.Sdk.PluginRegistration
             // 
             this.mnuContextGeneralSearch.Name = "mnuContextGeneralSearch";
             this.mnuContextGeneralSearch.ShortcutKeyDisplayString = "Ctrl+F";
-            this.mnuContextGeneralSearch.Size = new System.Drawing.Size(197, 22);
+            this.mnuContextGeneralSearch.Size = new System.Drawing.Size(269, 32);
             this.mnuContextGeneralSearch.Text = "&Search";
             this.mnuContextGeneralSearch.Click += new System.EventHandler(this.toolSearch_Click);
             // 
@@ -232,9 +235,11 @@ namespace Xrm.Sdk.PluginRegistration
             this.grpGrid.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.grpGrid.Controls.Add(this.grvData);
-            this.grpGrid.Location = new System.Drawing.Point(0, 479);
+            this.grpGrid.Location = new System.Drawing.Point(0, 737);
+            this.grpGrid.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.grpGrid.Name = "grpGrid";
-            this.grpGrid.Size = new System.Drawing.Size(845, 218);
+            this.grpGrid.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.grpGrid.Size = new System.Drawing.Size(1268, 335);
             this.grpGrid.TabIndex = 1;
             this.grpGrid.TabStop = false;
             // 
@@ -252,13 +257,15 @@ namespace Xrm.Sdk.PluginRegistration
             this.grvData.CellBorderStyle = System.Windows.Forms.DataGridViewCellBorderStyle.None;
             this.grvData.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.grvData.EditMode = System.Windows.Forms.DataGridViewEditMode.EditProgrammatically;
-            this.grvData.Location = new System.Drawing.Point(6, 12);
+            this.grvData.Location = new System.Drawing.Point(9, 18);
+            this.grvData.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.grvData.Name = "grvData";
+            this.grvData.RowHeadersWidth = 62;
             this.grvData.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
             this.grvData.ShowCellErrors = false;
             this.grvData.ShowEditingIcon = false;
             this.grvData.ShowRowErrors = false;
-            this.grvData.Size = new System.Drawing.Size(833, 200);
+            this.grvData.Size = new System.Drawing.Size(1250, 308);
             this.grvData.TabIndex = 1;
             this.grvData.RowEnter += new System.Windows.Forms.DataGridViewCellEventHandler(this.grvData_RowEnter);
             this.grvData.DoubleClick += new System.EventHandler(this.grvData_DoubleClick);
@@ -284,7 +291,8 @@ namespace Xrm.Sdk.PluginRegistration
             this.tsbFilterAssemblies});
             this.toolBar.Location = new System.Drawing.Point(0, 0);
             this.toolBar.Name = "toolBar";
-            this.toolBar.Size = new System.Drawing.Size(851, 25);
+            this.toolBar.Padding = new System.Windows.Forms.Padding(0, 0, 3, 0);
+            this.toolBar.Size = new System.Drawing.Size(1276, 34);
             this.toolBar.TabIndex = 9;
             this.toolBar.Text = "toolStrip1";
             // 
@@ -294,17 +302,18 @@ namespace Xrm.Sdk.PluginRegistration
             this.toolAssemblyRegister,
             this.toolStepRegister,
             this.toolImageRegister,
-            this.toolServiceEndpointRegister});
+            this.toolServiceEndpointRegister,
+            this.toolWebHookRegister});
             this.toolRegister.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.toolRegister.Name = "toolRegister";
-            this.toolRegister.Size = new System.Drawing.Size(62, 22);
+            this.toolRegister.Size = new System.Drawing.Size(93, 29);
             this.toolRegister.Text = "&Register";
             // 
             // toolAssemblyRegister
             // 
             this.toolAssemblyRegister.Name = "toolAssemblyRegister";
             this.toolAssemblyRegister.ShortcutKeyDisplayString = "Ctrl+A";
-            this.toolAssemblyRegister.Size = new System.Drawing.Size(274, 22);
+            this.toolAssemblyRegister.Size = new System.Drawing.Size(414, 34);
             this.toolAssemblyRegister.Text = "Register New &Assembly";
             this.toolAssemblyRegister.Click += new System.EventHandler(this.toolAssemblyRegister_Click);
             // 
@@ -312,7 +321,7 @@ namespace Xrm.Sdk.PluginRegistration
             // 
             this.toolStepRegister.Name = "toolStepRegister";
             this.toolStepRegister.ShortcutKeyDisplayString = "Ctrl+T";
-            this.toolStepRegister.Size = new System.Drawing.Size(274, 22);
+            this.toolStepRegister.Size = new System.Drawing.Size(414, 34);
             this.toolStepRegister.Text = "Register New S&tep";
             this.toolStepRegister.Click += new System.EventHandler(this.toolStepRegister_Click);
             // 
@@ -320,7 +329,7 @@ namespace Xrm.Sdk.PluginRegistration
             // 
             this.toolImageRegister.Name = "toolImageRegister";
             this.toolImageRegister.ShortcutKeyDisplayString = "Ctrl+I";
-            this.toolImageRegister.Size = new System.Drawing.Size(274, 22);
+            this.toolImageRegister.Size = new System.Drawing.Size(414, 34);
             this.toolImageRegister.Text = "Register New &Image";
             this.toolImageRegister.Click += new System.EventHandler(this.toolImageRegister_Click);
             // 
@@ -329,7 +338,7 @@ namespace Xrm.Sdk.PluginRegistration
             this.toolServiceEndpointRegister.Enabled = false;
             this.toolServiceEndpointRegister.Name = "toolServiceEndpointRegister";
             this.toolServiceEndpointRegister.ShortcutKeyDisplayString = "Ctrl+E";
-            this.toolServiceEndpointRegister.Size = new System.Drawing.Size(274, 22);
+            this.toolServiceEndpointRegister.Size = new System.Drawing.Size(414, 34);
             this.toolServiceEndpointRegister.Text = "Register New Service &Endpoint";
             this.toolServiceEndpointRegister.Visible = false;
             // 
@@ -341,14 +350,14 @@ namespace Xrm.Sdk.PluginRegistration
             this.toolViewMessage});
             this.toolView.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.toolView.Name = "toolView";
-            this.toolView.Size = new System.Drawing.Size(45, 22);
+            this.toolView.Size = new System.Drawing.Size(67, 29);
             this.toolView.Text = "View";
             // 
             // toolViewAssembly
             // 
             this.toolViewAssembly.Name = "toolViewAssembly";
             this.toolViewAssembly.ShortcutKeyDisplayString = "Ctrl+Shift+A";
-            this.toolViewAssembly.Size = new System.Drawing.Size(256, 22);
+            this.toolViewAssembly.Size = new System.Drawing.Size(390, 34);
             this.toolViewAssembly.Text = "Display by &Assembly";
             this.toolViewAssembly.Click += new System.EventHandler(this.toolView_Click);
             // 
@@ -356,7 +365,7 @@ namespace Xrm.Sdk.PluginRegistration
             // 
             this.toolViewEntity.Name = "toolViewEntity";
             this.toolViewEntity.ShortcutKeyDisplayString = "Ctrl+Shift+E";
-            this.toolViewEntity.Size = new System.Drawing.Size(256, 22);
+            this.toolViewEntity.Size = new System.Drawing.Size(390, 34);
             this.toolViewEntity.Text = "Display by &Entity";
             this.toolViewEntity.Click += new System.EventHandler(this.toolView_Click);
             // 
@@ -364,21 +373,21 @@ namespace Xrm.Sdk.PluginRegistration
             // 
             this.toolViewMessage.Name = "toolViewMessage";
             this.toolViewMessage.ShortcutKeyDisplayString = "Ctrl+Shift+M";
-            this.toolViewMessage.Size = new System.Drawing.Size(256, 22);
+            this.toolViewMessage.Size = new System.Drawing.Size(390, 34);
             this.toolViewMessage.Text = "Display by &Message";
             this.toolViewMessage.Click += new System.EventHandler(this.toolView_Click);
             // 
             // toolProfilerSep
             // 
             this.toolProfilerSep.Name = "toolProfilerSep";
-            this.toolProfilerSep.Size = new System.Drawing.Size(6, 25);
+            this.toolProfilerSep.Size = new System.Drawing.Size(6, 34);
             this.toolProfilerSep.Visible = false;
             // 
             // toolUpdate
             // 
             this.toolUpdate.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.toolUpdate.Name = "toolUpdate";
-            this.toolUpdate.Size = new System.Drawing.Size(49, 22);
+            this.toolUpdate.Size = new System.Drawing.Size(74, 29);
             this.toolUpdate.Text = "&Update";
             this.toolUpdate.Visible = false;
             this.toolUpdate.Click += new System.EventHandler(this.toolUpdate_Click);
@@ -387,7 +396,7 @@ namespace Xrm.Sdk.PluginRegistration
             // 
             this.toolEnable.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.toolEnable.Name = "toolEnable";
-            this.toolEnable.Size = new System.Drawing.Size(49, 22);
+            this.toolEnable.Size = new System.Drawing.Size(74, 29);
             this.toolEnable.Text = "&Disable";
             this.toolEnable.Visible = false;
             this.toolEnable.Click += new System.EventHandler(this.toolEnable_Click);
@@ -396,20 +405,20 @@ namespace Xrm.Sdk.PluginRegistration
             // 
             this.toolUnregister.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.toolUnregister.Name = "toolUnregister";
-            this.toolUnregister.Size = new System.Drawing.Size(65, 22);
+            this.toolUnregister.Size = new System.Drawing.Size(97, 29);
             this.toolUnregister.Text = "U&nregister";
             this.toolUnregister.Click += new System.EventHandler(this.toolUnregister_Click);
             // 
             // toolCommonSep2
             // 
             this.toolCommonSep2.Name = "toolCommonSep2";
-            this.toolCommonSep2.Size = new System.Drawing.Size(6, 25);
+            this.toolCommonSep2.Size = new System.Drawing.Size(6, 34);
             // 
             // toolRefresh
             // 
             this.toolRefresh.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.toolRefresh.Name = "toolRefresh";
-            this.toolRefresh.Size = new System.Drawing.Size(50, 22);
+            this.toolRefresh.Size = new System.Drawing.Size(74, 29);
             this.toolRefresh.Text = "Re&fresh";
             this.toolRefresh.Click += new System.EventHandler(this.toolRefresh_Click);
             // 
@@ -417,20 +426,20 @@ namespace Xrm.Sdk.PluginRegistration
             // 
             this.toolSearch.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.toolSearch.Name = "toolSearch";
-            this.toolSearch.Size = new System.Drawing.Size(46, 22);
+            this.toolSearch.Size = new System.Drawing.Size(68, 29);
             this.toolSearch.Text = "&Search";
             this.toolSearch.Click += new System.EventHandler(this.toolSearch_Click);
             // 
             // toolCommonSep3
             // 
             this.toolCommonSep3.Name = "toolCommonSep3";
-            this.toolCommonSep3.Size = new System.Drawing.Size(6, 25);
+            this.toolCommonSep3.Size = new System.Drawing.Size(6, 34);
             // 
             // toolExport
             // 
             this.toolExport.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.toolExport.Name = "toolExport";
-            this.toolExport.Size = new System.Drawing.Size(45, 22);
+            this.toolExport.Size = new System.Drawing.Size(67, 29);
             this.toolExport.Text = "E&xport";
             this.toolExport.ToolTipText = "Export to Excel";
             this.toolExport.Click += new System.EventHandler(this.toolExport_Click);
@@ -438,13 +447,13 @@ namespace Xrm.Sdk.PluginRegistration
             // toolStripSeparator1
             // 
             this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(6, 25);
+            this.toolStripSeparator1.Size = new System.Drawing.Size(6, 34);
             // 
             // toolClose
             // 
             this.toolClose.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.toolClose.Name = "toolClose";
-            this.toolClose.Size = new System.Drawing.Size(40, 22);
+            this.toolClose.Size = new System.Drawing.Size(59, 29);
             this.toolClose.Text = "Clos&e";
             this.toolClose.ToolTipText = "Close Tool (Ctrl+F4)";
             this.toolClose.Click += new System.EventHandler(this.toolClose_Click);
@@ -452,13 +461,13 @@ namespace Xrm.Sdk.PluginRegistration
             // toolStripSeparator2
             // 
             this.toolStripSeparator2.Name = "toolStripSeparator2";
-            this.toolStripSeparator2.Size = new System.Drawing.Size(6, 25);
+            this.toolStripSeparator2.Size = new System.Drawing.Size(6, 34);
             // 
             // tsbFilterAssemblies
             // 
             this.tsbFilterAssemblies.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.tsbFilterAssemblies.Name = "tsbFilterAssemblies";
-            this.tsbFilterAssemblies.Size = new System.Drawing.Size(99, 22);
+            this.tsbFilterAssemblies.Size = new System.Drawing.Size(148, 29);
             this.tsbFilterAssemblies.Text = "Filter Assemblies";
             this.tsbFilterAssemblies.ToolTipText = "No filter(s) set";
             this.tsbFilterAssemblies.Click += new System.EventHandler(this.tsbFilterAssemblies_Click);
@@ -474,7 +483,8 @@ namespace Xrm.Sdk.PluginRegistration
             this.splitterDisplay.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.splitterDisplay.Location = new System.Drawing.Point(0, 28);
+            this.splitterDisplay.Location = new System.Drawing.Point(0, 43);
+            this.splitterDisplay.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.splitterDisplay.Name = "splitterDisplay";
             // 
             // splitterDisplay.Panel1
@@ -485,8 +495,9 @@ namespace Xrm.Sdk.PluginRegistration
             // 
             this.splitterDisplay.Panel2.Controls.Add(this.btnSave);
             this.splitterDisplay.Panel2.Controls.Add(this.propGridEntity);
-            this.splitterDisplay.Size = new System.Drawing.Size(848, 445);
-            this.splitterDisplay.SplitterDistance = 562;
+            this.splitterDisplay.Size = new System.Drawing.Size(1272, 685);
+            this.splitterDisplay.SplitterDistance = 843;
+            this.splitterDisplay.SplitterWidth = 6;
             this.splitterDisplay.TabIndex = 11;
             // 
             // grpPlugins
@@ -496,8 +507,10 @@ namespace Xrm.Sdk.PluginRegistration
             | System.Windows.Forms.AnchorStyles.Right)));
             this.grpPlugins.Controls.Add(this.trvPlugins);
             this.grpPlugins.Location = new System.Drawing.Point(0, 0);
+            this.grpPlugins.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.grpPlugins.Name = "grpPlugins";
-            this.grpPlugins.Size = new System.Drawing.Size(559, 442);
+            this.grpPlugins.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.grpPlugins.Size = new System.Drawing.Size(838, 680);
             this.grpPlugins.TabIndex = 1;
             this.grpPlugins.TabStop = false;
             this.grpPlugins.Text = "Registered Plugins && Custom Workflow Activities";
@@ -511,12 +524,12 @@ namespace Xrm.Sdk.PluginRegistration
             this.trvPlugins.ContextMenuStrip = this.mnuContextNode;
             this.trvPlugins.CrmTreeNodeSorter = null;
             this.trvPlugins.LabelEdit = true;
-            this.trvPlugins.Location = new System.Drawing.Point(6, 14);
-            this.trvPlugins.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.trvPlugins.Location = new System.Drawing.Point(9, 22);
+            this.trvPlugins.Margin = new System.Windows.Forms.Padding(6, 8, 6, 8);
             this.trvPlugins.Name = "trvPlugins";
             this.trvPlugins.SelectedNode = null;
             this.trvPlugins.ShowNodeToolTips = false;
-            this.trvPlugins.Size = new System.Drawing.Size(547, 422);
+            this.trvPlugins.Size = new System.Drawing.Size(820, 649);
             this.trvPlugins.TabIndex = 0;
             this.trvPlugins.DoubleClick += new System.EventHandler<Xrm.Sdk.PluginRegistration.Controls.CrmTreeNodeEventArgs>(this.trvPlugins_DoubleClick);
             this.trvPlugins.NodeRemoved += new System.EventHandler<Xrm.Sdk.PluginRegistration.Controls.CrmTreeNodeEventArgs>(this.trvPlugins_NodeRemoved);
@@ -526,9 +539,10 @@ namespace Xrm.Sdk.PluginRegistration
             // 
             this.btnSave.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.btnSave.Enabled = false;
-            this.btnSave.Location = new System.Drawing.Point(194, 413);
+            this.btnSave.Location = new System.Drawing.Point(291, 635);
+            this.btnSave.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.btnSave.Name = "btnSave";
-            this.btnSave.Size = new System.Drawing.Size(75, 23);
+            this.btnSave.Size = new System.Drawing.Size(112, 35);
             this.btnSave.TabIndex = 5;
             this.btnSave.Text = "Save";
             this.btnSave.UseVisualStyleBackColor = true;
@@ -540,20 +554,30 @@ namespace Xrm.Sdk.PluginRegistration
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.propGridEntity.Location = new System.Drawing.Point(0, 0);
+            this.propGridEntity.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.propGridEntity.Name = "propGridEntity";
-            this.propGridEntity.Size = new System.Drawing.Size(270, 407);
+            this.propGridEntity.Size = new System.Drawing.Size(405, 626);
             this.propGridEntity.TabIndex = 4;
+            // 
+            // toolWebHookRegister
+            // 
+            this.toolWebHookRegister.Name = "toolWebHookRegister";
+            this.toolWebHookRegister.ShortcutKeyDisplayString = "Ctrl+W";
+            this.toolWebHookRegister.Size = new System.Drawing.Size(414, 34);
+            this.toolWebHookRegister.Text = "Register New Web Hook";
+            this.toolWebHookRegister.Click += new System.EventHandler(this.toolWebHookRegister_Click);
             // 
             // MainControl
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ContextMenuStrip = this.mnuContextGeneral;
             this.Controls.Add(this.splitterDisplay);
             this.Controls.Add(this.toolBar);
             this.Controls.Add(this.grpGrid);
+            this.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.Name = "MainControl";
-            this.Size = new System.Drawing.Size(851, 697);
+            this.Size = new System.Drawing.Size(1276, 1072);
             this.mnuContextNode.ResumeLayout(false);
             this.mnuContextGeneral.ResumeLayout(false);
             this.grpGrid.ResumeLayout(false);
@@ -621,5 +645,6 @@ namespace Xrm.Sdk.PluginRegistration
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
         private System.Windows.Forms.ToolStripButton tsbFilterAssemblies;
+        private System.Windows.Forms.ToolStripMenuItem toolWebHookRegister;
     }
 }

--- a/Xrm.Sdk.PluginRegistration/Wrappers/CrmPluginStep.cs
+++ b/Xrm.Sdk.PluginRegistration/Wrappers/CrmPluginStep.cs
@@ -703,13 +703,13 @@ namespace Xrm.Sdk.PluginRegistration.Wrappers
 
             sdkStep.Configuration = UnsecureConfiguration;
 
-            if (ServiceBusConfigurationId == Guid.Empty)
+            if (AssemblyId != Guid.Empty && PluginId != Guid.Empty)
             {
                 sdkStep.EventHandler = new EntityReference(PluginType.EntityLogicalName, PluginId);
             }
             else
             {
-                sdkStep.EventHandler = new EntityReference(ServiceEndpoint.EntityLogicalName, ServiceBusConfigurationId);
+                sdkStep.EventHandler = new EntityReference(ServiceEndpoint.EntityLogicalName,  ServiceBusConfigurationId == Guid.Empty ? PluginId : ServiceBusConfigurationId);
             }
 
             sdkStep.Name = Name;

--- a/Xrm.Sdk.PluginRegistration/Xrm.Sdk.PluginRegistration.csproj
+++ b/Xrm.Sdk.PluginRegistration/Xrm.Sdk.PluginRegistration.csproj
@@ -259,6 +259,12 @@
     <Compile Include="Forms\ExportTypeSelectionForm.Designer.cs">
       <DependentUpon>ExportTypeSelectionForm.cs</DependentUpon>
     </Compile>
+    <Compile Include="Forms\WebHookRegistrationForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Forms\WebHookRegistrationForm.Designer.cs">
+      <DependentUpon>WebHookRegistrationForm.cs</DependentUpon>
+    </Compile>
     <Compile Include="Plugin.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="AssemblyReader.cs" />
@@ -426,6 +432,9 @@
     <EmbeddedResource Include="Forms\MessagePropertyNameForm.resx">
       <SubType>Designer</SubType>
       <DependentUpon>MessagePropertyNameForm.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Forms\WebHookRegistrationForm.resx">
+      <DependentUpon>WebHookRegistrationForm.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="MainControl.resx">
       <SubType>Designer</SubType>


### PR DESCRIPTION
This PR is adding webhooks support to the tool. You can now easily register and edit webhooks on your instance like you are used to while using the Microsoft Plugin Registration Tool.

A new webhook can be created via a button located in the **Register** flyout button in the toolbar.

![prt-create-wh](https://user-images.githubusercontent.com/31212465/97552044-0f933980-19d4-11eb-8572-3ab256a02ce0.png)

After you select the **Register New Web Hook** option you will get a popup window to fill in the webhook details.

![prt-new-webhook](https://user-images.githubusercontent.com/31212465/97552373-7a447500-19d4-11eb-8467-12bebb3c3523.png)

When you register your webhook all you need to do it define webhook steps and that process is the same as adding the steps to a plugin.