### PR TITLE
Results in Search window are anchored to top and resize with the dialog.

### DIFF
--- a/Xrm.Sdk.PluginRegistration/Forms/SearchForm.Designer.cs
+++ b/Xrm.Sdk.PluginRegistration/Forms/SearchForm.Designer.cs
@@ -68,7 +68,8 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             // 
             // trvPlugins
             // 
-            this.trvPlugins.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            this.trvPlugins.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.trvPlugins.AutoExpand = false;
             this.trvPlugins.CrmTreeNodeSorter = null;


### PR DESCRIPTION
`trvPlugins` tree control  in `SearchForm` is now anchored to the top so it's possible to resize search results:

## Before 
![search-before](https://user-images.githubusercontent.com/185621/121268784-de121300-c8be-11eb-8dcd-922d940ad382.gif)

## After
![search-after](https://user-images.githubusercontent.com/185621/121268833-fda93b80-c8be-11eb-9f9f-dbae6cfff6f3.gif)
