### PR TITLE
Webhook.site integration for testing webhooks

### DIFF
--- a/Xrm.Sdk.PluginRegistration.Tests/app.config
+++ b/Xrm.Sdk.PluginRegistration.Tests/app.config
@@ -64,7 +64,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Security.Cryptography.Pkcs" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.4" newVersion="6.0.0.4" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Security.Cryptography.Cng" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
@@ -72,23 +72,23 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Common" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.9.3.3" newVersion="5.9.3.3" />
+        <bindingRedirect oldVersion="0.0.0.0-6.7.0.127" newVersion="6.7.0.127" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Protocol" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.9.1.11" newVersion="5.9.1.11" />
+        <bindingRedirect oldVersion="0.0.0.0-6.7.0.127" newVersion="6.7.0.127" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Versioning" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.9.3.3" newVersion="5.9.3.3" />
+        <bindingRedirect oldVersion="0.0.0.0-6.7.0.127" newVersion="6.7.0.127" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Packaging" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.9.3.3" newVersion="5.9.3.3" />
+        <bindingRedirect oldVersion="0.0.0.0-6.7.0.127" newVersion="6.7.0.127" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Configuration" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.9.3.3" newVersion="5.9.3.3" />
+        <bindingRedirect oldVersion="0.0.0.0-6.7.0.127" newVersion="6.7.0.127" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
@@ -100,7 +100,11 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Frameworks" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.9.3.3" newVersion="5.9.3.3" />
+        <bindingRedirect oldVersion="0.0.0.0-5.10.0.7240" newVersion="5.10.0.7240" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Xrm.Sdk.PluginRegistration/Forms/WebHookRegistrationForm.Designer.cs
+++ b/Xrm.Sdk.PluginRegistration/Forms/WebHookRegistrationForm.Designer.cs
@@ -41,13 +41,14 @@
             this.dgvKeyValue = new System.Windows.Forms.DataGridView();
             this.Keys = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Values = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.btnGenerateWebhookSite = new System.Windows.Forms.Button();
             ((System.ComponentModel.ISupportInitialize)(this.dgvKeyValue)).BeginInit();
             this.SuspendLayout();
             // 
             // lblName
             // 
             this.lblName.AutoSize = true;
-            this.lblName.Location = new System.Drawing.Point(12, 23);
+            this.lblName.Location = new System.Drawing.Point(12, 67);
             this.lblName.Name = "lblName";
             this.lblName.Size = new System.Drawing.Size(51, 20);
             this.lblName.TabIndex = 0;
@@ -55,14 +56,14 @@
             // 
             // txtName
             // 
-            this.txtName.Location = new System.Drawing.Point(161, 20);
+            this.txtName.Location = new System.Drawing.Point(161, 64);
             this.txtName.Name = "txtName";
             this.txtName.Size = new System.Drawing.Size(627, 26);
             this.txtName.TabIndex = 1;
             // 
             // txtEndpointUrl
             // 
-            this.txtEndpointUrl.Location = new System.Drawing.Point(161, 71);
+            this.txtEndpointUrl.Location = new System.Drawing.Point(161, 115);
             this.txtEndpointUrl.Name = "txtEndpointUrl";
             this.txtEndpointUrl.Size = new System.Drawing.Size(627, 26);
             this.txtEndpointUrl.TabIndex = 3;
@@ -70,7 +71,7 @@
             // lblEndpointUrl
             // 
             this.lblEndpointUrl.AutoSize = true;
-            this.lblEndpointUrl.Location = new System.Drawing.Point(12, 74);
+            this.lblEndpointUrl.Location = new System.Drawing.Point(12, 118);
             this.lblEndpointUrl.Name = "lblEndpointUrl";
             this.lblEndpointUrl.Size = new System.Drawing.Size(110, 20);
             this.lblEndpointUrl.TabIndex = 2;
@@ -79,7 +80,7 @@
             // lblAuth
             // 
             this.lblAuth.AutoSize = true;
-            this.lblAuth.Location = new System.Drawing.Point(12, 128);
+            this.lblAuth.Location = new System.Drawing.Point(12, 172);
             this.lblAuth.Name = "lblAuth";
             this.lblAuth.Size = new System.Drawing.Size(112, 20);
             this.lblAuth.TabIndex = 4;
@@ -93,7 +94,7 @@
             "HttpHeader",
             "WebhookKey",
             "HttpQueryString"});
-            this.cmbAuth.Location = new System.Drawing.Point(161, 125);
+            this.cmbAuth.Location = new System.Drawing.Point(161, 169);
             this.cmbAuth.Name = "cmbAuth";
             this.cmbAuth.Size = new System.Drawing.Size(627, 28);
             this.cmbAuth.TabIndex = 5;
@@ -102,7 +103,7 @@
             // lblValue
             // 
             this.lblValue.AutoSize = true;
-            this.lblValue.Location = new System.Drawing.Point(12, 186);
+            this.lblValue.Location = new System.Drawing.Point(12, 230);
             this.lblValue.Name = "lblValue";
             this.lblValue.Size = new System.Drawing.Size(50, 20);
             this.lblValue.TabIndex = 6;
@@ -110,14 +111,14 @@
             // 
             // txtValue
             // 
-            this.txtValue.Location = new System.Drawing.Point(161, 183);
+            this.txtValue.Location = new System.Drawing.Point(161, 227);
             this.txtValue.Name = "txtValue";
             this.txtValue.Size = new System.Drawing.Size(627, 26);
             this.txtValue.TabIndex = 7;
             // 
             // btnSave
             // 
-            this.btnSave.Location = new System.Drawing.Point(598, 401);
+            this.btnSave.Location = new System.Drawing.Point(598, 445);
             this.btnSave.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.btnSave.Name = "btnSave";
             this.btnSave.Size = new System.Drawing.Size(91, 35);
@@ -128,7 +129,7 @@
             // 
             // btnCancel
             // 
-            this.btnCancel.Location = new System.Drawing.Point(697, 401);
+            this.btnCancel.Location = new System.Drawing.Point(697, 445);
             this.btnCancel.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(91, 35);
@@ -144,7 +145,7 @@
             this.dgvKeyValue.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.Keys,
             this.Values});
-            this.dgvKeyValue.Location = new System.Drawing.Point(16, 182);
+            this.dgvKeyValue.Location = new System.Drawing.Point(16, 226);
             this.dgvKeyValue.Name = "dgvKeyValue";
             this.dgvKeyValue.RowHeadersWidth = 62;
             this.dgvKeyValue.RowTemplate.Height = 28;
@@ -163,11 +164,23 @@
             this.Values.MinimumWidth = 8;
             this.Values.Name = "Values";
             // 
+            // btnGenerateWebhookSite
+            // 
+            this.btnGenerateWebhookSite.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.btnGenerateWebhookSite.Location = new System.Drawing.Point(161, 12);
+            this.btnGenerateWebhookSite.Name = "btnGenerateWebhookSite";
+            this.btnGenerateWebhookSite.Size = new System.Drawing.Size(627, 35);
+            this.btnGenerateWebhookSite.TabIndex = 11;
+            this.btnGenerateWebhookSite.Text = "Generate Test Url";
+            this.btnGenerateWebhookSite.UseVisualStyleBackColor = true;
+            this.btnGenerateWebhookSite.Click += new System.EventHandler(this.btnGenerateWebhookSite_Click);
+            // 
             // WebHookRegistrationForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(800, 450);
+            this.ClientSize = new System.Drawing.Size(800, 494);
+            this.Controls.Add(this.btnGenerateWebhookSite);
             this.Controls.Add(this.dgvKeyValue);
             this.Controls.Add(this.btnCancel);
             this.Controls.Add(this.btnSave);
@@ -206,5 +219,6 @@
         private System.Windows.Forms.DataGridView dgvKeyValue;
         private System.Windows.Forms.DataGridViewTextBoxColumn Keys;
         private System.Windows.Forms.DataGridViewTextBoxColumn Values;
+        private System.Windows.Forms.Button btnGenerateWebhookSite;
     }
 }

--- a/Xrm.Sdk.PluginRegistration/Forms/WebHookRegistrationForm.Designer.cs
+++ b/Xrm.Sdk.PluginRegistration/Forms/WebHookRegistrationForm.Designer.cs
@@ -28,6 +28,7 @@
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
             this.lblName = new System.Windows.Forms.Label();
             this.txtName = new System.Windows.Forms.TextBox();
             this.txtEndpointUrl = new System.Windows.Forms.TextBox();
@@ -42,6 +43,7 @@
             this.Keys = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Values = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.btnGenerateWebhookSite = new System.Windows.Forms.Button();
+            this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
             ((System.ComponentModel.ISupportInitialize)(this.dgvKeyValue)).BeginInit();
             this.SuspendLayout();
             // 
@@ -172,6 +174,7 @@
             this.btnGenerateWebhookSite.Size = new System.Drawing.Size(627, 35);
             this.btnGenerateWebhookSite.TabIndex = 11;
             this.btnGenerateWebhookSite.Text = "Generate Test Url";
+            this.toolTip1.SetToolTip(this.btnGenerateWebhookSite, "Generate a new webhook URL on Webhook.site service");
             this.btnGenerateWebhookSite.UseVisualStyleBackColor = true;
             this.btnGenerateWebhookSite.Click += new System.EventHandler(this.btnGenerateWebhookSite_Click);
             // 
@@ -220,5 +223,6 @@
         private System.Windows.Forms.DataGridViewTextBoxColumn Keys;
         private System.Windows.Forms.DataGridViewTextBoxColumn Values;
         private System.Windows.Forms.Button btnGenerateWebhookSite;
+        private System.Windows.Forms.ToolTip toolTip1;
     }
 }

--- a/Xrm.Sdk.PluginRegistration/Forms/WebHookRegistrationForm.cs
+++ b/Xrm.Sdk.PluginRegistration/Forms/WebHookRegistrationForm.cs
@@ -188,13 +188,15 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             var webhookSiteResponse = JsonConvert.DeserializeObject<WebhookSiteResponse>(responseJson);
             var webhookId = webhookSiteResponse?.uuid;
 
+            var webhookMonitorUrl = $"{baseUrl}/#!/{webhookId}";
+            Clipboard.SetText(webhookMonitorUrl);
+
             txtEndpointUrl.Text = $"{baseUrl}/{webhookId}";
             cmbAuth.SelectedIndex = 1;
             txtValue.Text = "123";
-            txtName.Text = string.IsNullOrEmpty(txtName.Text) ? "Test Webhook Site" : txtName.Text;
-
-            var webhookMonitorUrl = $"{baseUrl}/#!/{webhookId}";
-            Clipboard.SetText(webhookMonitorUrl);
+            txtName.Text = string.IsNullOrEmpty(txtName.Text) 
+                ? $"Webhook.site: {webhookMonitorUrl}"
+                : txtName.Text;
 
             var dialogResponse = MessageBox.Show(
                 $"Would you like to open the Webhook.site monitor in your browser?\n\nPlease note that the URL for the Webhook monitor has been copied to your clipboard.",

--- a/Xrm.Sdk.PluginRegistration/Forms/WebHookRegistrationForm.resx
+++ b/Xrm.Sdk.PluginRegistration/Forms/WebHookRegistrationForm.resx
@@ -123,10 +123,7 @@
   <metadata name="Values.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <metadata name="Keys.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="Values.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
   </metadata>
 </root>

--- a/Xrm.Sdk.PluginRegistration/Models/WebhookSiteResponse.cs
+++ b/Xrm.Sdk.PluginRegistration/Models/WebhookSiteResponse.cs
@@ -1,0 +1,25 @@
+﻿namespace Xrm.Sdk.PluginRegistration.Models
+{
+    public class WebhookSiteResponse
+    {
+        public string uuid { get; set; }
+        public bool redirect { get; set; }
+        public object alias { get; set; }
+        public bool actions { get; set; }
+        public bool cors { get; set; }
+        public bool expiry { get; set; }
+        public int timeout { get; set; }
+        public bool premium { get; set; }
+        public object user_id { get; set; }
+        public bool password { get; set; }
+        public string ip { get; set; }
+        public string user_agent { get; set; }
+        public string default_content { get; set; }
+        public int default_status { get; set; }
+        public string default_content_type { get; set; }
+        public object premium_expires_at { get; set; }
+        public object description { get; set; }
+        public string created_at { get; set; }
+        public string updated_at { get; set; }
+    }
+}

--- a/Xrm.Sdk.PluginRegistration/Xrm.Sdk.PluginRegistration.csproj
+++ b/Xrm.Sdk.PluginRegistration/Xrm.Sdk.PluginRegistration.csproj
@@ -511,6 +511,7 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Forms\WebHookRegistrationForm.resx">
       <DependentUpon>WebHookRegistrationForm.cs</DependentUpon>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="MainControl.resx">
       <SubType>Designer</SubType>

--- a/Xrm.Sdk.PluginRegistration/Xrm.Sdk.PluginRegistration.csproj
+++ b/Xrm.Sdk.PluginRegistration/Xrm.Sdk.PluginRegistration.csproj
@@ -142,23 +142,23 @@
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Common, Version=5.9.3.3, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\NuGet.Common.5.9.3\lib\net45\NuGet.Common.dll</HintPath>
+    <Reference Include="NuGet.Common, Version=6.7.0.127, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\NuGet.Common.6.7.0\lib\netstandard2.0\NuGet.Common.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Configuration, Version=5.9.3.3, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\NuGet.Configuration.5.9.3\lib\net45\NuGet.Configuration.dll</HintPath>
+    <Reference Include="NuGet.Configuration, Version=6.7.0.127, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\NuGet.Configuration.6.7.0\lib\netstandard2.0\NuGet.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Frameworks, Version=5.9.3.3, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\NuGet.Frameworks.5.9.3\lib\net40\NuGet.Frameworks.dll</HintPath>
+    <Reference Include="NuGet.Frameworks, Version=6.7.0.127, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\NuGet.Frameworks.6.7.0\lib\netstandard2.0\NuGet.Frameworks.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Packaging, Version=5.9.3.3, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\NuGet.Packaging.5.9.3\lib\netstandard2.0\NuGet.Packaging.dll</HintPath>
+    <Reference Include="NuGet.Packaging, Version=6.7.0.127, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\NuGet.Packaging.6.7.0\lib\netstandard2.0\NuGet.Packaging.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Protocol, Version=5.9.1.11, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\NuGet.Protocol.5.9.1\lib\netstandard2.0\NuGet.Protocol.dll</HintPath>
+    <Reference Include="NuGet.Protocol, Version=6.7.0.127, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\NuGet.Protocol.6.7.0\lib\netstandard2.0\NuGet.Protocol.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Versioning, Version=5.9.3.3, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\NuGet.Versioning.5.9.3\lib\net45\NuGet.Versioning.dll</HintPath>
+    <Reference Include="NuGet.Versioning, Version=6.7.0.127, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\NuGet.Versioning.6.7.0\lib\netstandard2.0\NuGet.Versioning.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
@@ -214,11 +214,14 @@
     <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
     </Reference>
-    <Reference Include="System.Security.Cryptography.Pkcs, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.Cryptography.Pkcs.5.0.0\lib\net461\System.Security.Cryptography.Pkcs.dll</HintPath>
+    <Reference Include="System.Security.Cryptography.Pkcs, Version=6.0.0.4, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Pkcs.6.0.4\lib\net461\System.Security.Cryptography.Pkcs.dll</HintPath>
     </Reference>
     <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.ProtectedData, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.ProtectedData.4.4.0\lib\net461\System.Security.Cryptography.ProtectedData.dll</HintPath>
     </Reference>
     <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.2, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.2\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
@@ -327,6 +330,7 @@
     </Compile>
     <Compile Include="Helpers\ListViewItemComparer.cs" />
     <Compile Include="Models\Solution.Static.cs" />
+    <Compile Include="Models\WebhookSiteResponse.cs" />
     <Compile Include="Plugin.cs" />
     <Compile Include="PluginAssemblyFileMapping.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Xrm.Sdk.PluginRegistration/app.config
+++ b/Xrm.Sdk.PluginRegistration/app.config
@@ -60,7 +60,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Security.Cryptography.Pkcs" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.4" newVersion="6.0.0.4" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Security.Cryptography.Cng" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
@@ -68,23 +68,23 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Common" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.9.3.3" newVersion="5.9.3.3" />
+        <bindingRedirect oldVersion="0.0.0.0-6.7.0.127" newVersion="6.7.0.127" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Protocol" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.9.1.11" newVersion="5.9.1.11" />
+        <bindingRedirect oldVersion="0.0.0.0-6.7.0.127" newVersion="6.7.0.127" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Versioning" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.9.3.3" newVersion="5.9.3.3" />
+        <bindingRedirect oldVersion="0.0.0.0-6.7.0.127" newVersion="6.7.0.127" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Packaging" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.9.3.3" newVersion="5.9.3.3" />
+        <bindingRedirect oldVersion="0.0.0.0-6.7.0.127" newVersion="6.7.0.127" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Configuration" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.9.3.3" newVersion="5.9.3.3" />
+        <bindingRedirect oldVersion="0.0.0.0-6.7.0.127" newVersion="6.7.0.127" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
@@ -97,7 +97,11 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Frameworks" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.9.3.3" newVersion="5.9.3.3" />
+        <bindingRedirect oldVersion="0.0.0.0-5.10.0.7240" newVersion="5.10.0.7240" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Xrm.Sdk.PluginRegistration/packages.config
+++ b/Xrm.Sdk.PluginRegistration/packages.config
@@ -26,12 +26,12 @@
   <package id="Microsoft.Web.Xdt" version="3.1.0" targetFramework="net462" />
   <package id="MscrmTools.Xrm.Connection" version="1.2022.10.54" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net462" />
-  <package id="NuGet.Common" version="5.9.3" targetFramework="net462" />
-  <package id="NuGet.Configuration" version="5.9.3" targetFramework="net462" />
-  <package id="NuGet.Frameworks" version="5.9.3" targetFramework="net462" />
-  <package id="NuGet.Packaging" version="5.9.3" targetFramework="net462" />
-  <package id="NuGet.Protocol" version="5.9.3" targetFramework="net462" />
-  <package id="NuGet.Versioning" version="5.9.3" targetFramework="net462" />
+  <package id="NuGet.Common" version="6.7.0" targetFramework="net462" />
+  <package id="NuGet.Configuration" version="6.7.0" targetFramework="net462" />
+  <package id="NuGet.Frameworks" version="6.7.0" targetFramework="net462" />
+  <package id="NuGet.Packaging" version="6.7.0" targetFramework="net462" />
+  <package id="NuGet.Protocol" version="6.7.0" targetFramework="net462" />
+  <package id="NuGet.Versioning" version="6.7.0" targetFramework="net462" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net462" />
   <package id="System.ComponentModel.Annotations" version="5.0.0" targetFramework="net462" />
   <package id="System.Memory" version="4.5.4" targetFramework="net462" />
@@ -42,8 +42,9 @@
   <package id="System.Security.Cryptography.Algorithms" version="4.3.1" targetFramework="net462" />
   <package id="System.Security.Cryptography.Cng" version="5.0.0" targetFramework="net462" />
   <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net462" />
-  <package id="System.Security.Cryptography.Pkcs" version="5.0.0" targetFramework="net462" />
+  <package id="System.Security.Cryptography.Pkcs" version="6.0.4" targetFramework="net462" />
   <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net462" />
+  <package id="System.Security.Cryptography.ProtectedData" version="4.4.0" targetFramework="net462" />
   <package id="System.Security.Cryptography.X509Certificates" version="4.3.2" targetFramework="net462" />
   <package id="System.Text.Encodings.Web" version="6.0.0" targetFramework="net462" />
   <package id="System.Text.Json" version="6.0.2" targetFramework="net462" />


### PR DESCRIPTION
I have been using webhooks a lot lately and when I want to test the messages that are being sent via webhook payload I use [Webhook.ste](https://webhook.site/) service.

Automated process via a button in the configuration:

1. Create a new webhook URL on Webhook.site via HTTP request
2. Populate webhook configuration in the popup
3. Monitor URL is copied to the clipboard
4. **(Optional)** Opening the browser on the webhook monitor page

There are several clicks that I do over and over again every time I want to set up the webhook configuration. With this feature, everything is initiated with a click of a button in the configuration.