### PR TITLE
Fixed broken Webhook Site API

### DIFF
--- a/Xrm.Sdk.PluginRegistration/Models/WebhookSiteResponse.cs
+++ b/Xrm.Sdk.PluginRegistration/Models/WebhookSiteResponse.cs
@@ -7,7 +7,7 @@
         public object alias { get; set; }
         public bool actions { get; set; }
         public bool cors { get; set; }
-        public bool expiry { get; set; }
+        public bool? expiry { get; set; }
         public int timeout { get; set; }
         public bool premium { get; set; }
         public object user_id { get; set; }


### PR DESCRIPTION
The Webhook site started sending NULL values in JSON for the expiry field which caused an exception when executing the API.