### PR TITLE
Packages

### DIFF
--- a/Xrm.Sdk.PluginRegistration/Forms/PackageRegistrationForm.cs
+++ b/Xrm.Sdk.PluginRegistration/Forms/PackageRegistrationForm.cs
@@ -120,11 +120,31 @@ namespace Xrm.Sdk.PluginRegistration.Forms
                             doc.Load(xReader);
 
                             XmlNamespaceManager nsmgr = new XmlNamespaceManager(doc.NameTable);
-                            nsmgr.AddNamespace("ns", "http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd");
+                            nsmgr.AddNamespace("ns", doc.DocumentElement.NamespaceURI);
 
                             var metadata = doc.SelectSingleNode("ns:package/ns:metadata", nsmgr);
-                            id = metadata.SelectSingleNode("ns:id", nsmgr).InnerText;
-                            version = metadata.SelectSingleNode("ns:version", nsmgr).InnerText;
+
+                            if (metadata == null)
+                            {
+                                MessageBox.Show(this, "Package metadata not found\r\n\r\nCould not find the package/metadata node in " + part.Uri, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                                return;
+                            }
+
+                            id = metadata.SelectSingleNode("ns:id", nsmgr)?.InnerText;
+
+                            if (id == null)
+                            {
+                                MessageBox.Show(this, "Package metadata not found\r\n\r\nCould not find the package/metadata/id node in " + part.Uri, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                                return;
+                            }
+
+                            version = metadata.SelectSingleNode("ns:version", nsmgr)?.InnerText;
+
+                            if (version == null)
+                            {
+                                MessageBox.Show(this, "Package metadata not found\r\n\r\nCould not find the package/metadata/version node in " + part.Uri, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                                return;
+                            }
                         }
                     }
                 }

--- a/Xrm.Sdk.PluginRegistration/Forms/PackageRegistrationForm.cs
+++ b/Xrm.Sdk.PluginRegistration/Forms/PackageRegistrationForm.cs
@@ -88,7 +88,8 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             txtName.Text = package.Name.Split('_')[1];
             txtVersion.Text = package.Version;
 
-            AnalyzePackage();
+            if (!String.IsNullOrEmpty(txtPluginPackageFile.Text))
+                AnalyzePackage();
 
             Height = Height - 50;
         }


### PR DESCRIPTION
The package registration form is expecting the nuspec file to be using a specific version of the NuGet schema. Depending on the build tools being used, this might be a different version which leads to a NullReferenceException when attempting to find the metadata within the file.

This change takes whatever version is being used in the package rather than making any assumptions, which should allow it to work if new versions are introduced in the future as well.

In case some other problem leads to the expected metadata not being present, some more helpful error messages will be displayed instead of the current uncaught exception handler.